### PR TITLE
Adding new Basf2nTupleMergeTask and an example for a basf2 workflow

### DIFF
--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -6,5 +6,5 @@ from luigi import *
 from luigi.util import requires, inherits
 
 from b2luigi.core.tasks import Task, ExternalTask, WrapperTask, DispatchableTask, ROOTLocalTarget
-from b2luigi.core.helper_tasks import Basf2Task, SimplifiedOutputBasf2Task, Basf2FileMergeTask, HaddTask
+from b2luigi.core.helper_tasks import Basf2Task, SimplifiedOutputBasf2Task, Basf2FileMergeTask, Basf2nTupleMergeTask, HaddTask
 from b2luigi.cli.process import process

--- a/b2luigi/core/helper_tasks.py
+++ b/b2luigi/core/helper_tasks.py
@@ -101,3 +101,14 @@ class Basf2FileMergeTask(HaddTask):
                 continue
             args = ["b2file-merge", "-f", self.get_output_file_name(key)] + file_list
             subprocess.check_call(args)
+
+
+class Basf2nTupleMergeTask(HaddTask):
+    def run(self):
+        self.create_output_dirs()
+
+        for key, file_list in self.get_transposed_input_file_names().items():
+            if hasattr(self, "keys") and key not in self.keys:
+                continue
+            args = ["fei_merge_files", self.get_output_file_name(key)] + file_list
+            subprocess.check_call(args)

--- a/examples/basf2_chain_example.py
+++ b/examples/basf2_chain_example.py
@@ -1,0 +1,124 @@
+import b2luigi
+import basf2
+import luigi
+
+
+class SimulationTask(b2luigi.Basf2Task):
+    n_events = luigi.IntParameter()
+    event_type = luigi.Parameter()
+
+    def create_path(self):
+        import modularAnalysis
+        import simulation
+        import generators
+        from ROOT import Belle2
+
+        path = basf2.create_path()
+
+        modularAnalysis.setupEventInfo(self.n_events, path)
+
+        if self.event_type == 'Y4S':
+            dec_file = Belle2.FileSystem.findFile('analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec')
+        elif self.event_type == 'Continuum':
+            dec_file = Belle2.FileSystem.findFile('analysis/examples/tutorials/B2A102-ccbarEventGeneration.dec')
+        else:
+            raise ValueError(f"Event type {self.event_type} is not valid. It should be either 'Y(4S)' or 'Continuum'!")
+        generators.add_evtgen_generator(path, 'signal', dec_file)
+
+        modularAnalysis.loadGearbox(path)
+
+        simulation.add_simulation(path)
+
+        path.add_module('RootOutput', outputFileName=self.get_output_file_names()['simulation_full_output.root'])
+
+        return path
+
+    def output(self):
+        yield self.add_to_output("simulation_full_output.root")
+
+
+class ReconstructionTask(b2luigi.Basf2Task):
+    n_events = luigi.IntParameter()
+    event_type = luigi.Parameter()
+
+    def create_path(self):
+        import modularAnalysis
+        import reconstruction
+
+        path = basf2.create_path()
+
+        path.add_module(
+            'RootInput',
+            inputFileNames=self.get_input_file_names()["simulation_full_output.root"]
+        )
+
+        modularAnalysis.loadGearbox(path)
+        reconstruction.add_reconstruction(path)
+
+        modularAnalysis.outputMdst(self.get_output_file_names()["reconstructed_output.root"], path=path)
+
+        return path
+
+    def output(self):
+        yield self.add_to_output("reconstructed_output.root")
+
+    def requires(self):
+        yield self.clone(SimulationTask)
+
+
+class AnalysisTask(b2luigi.Basf2Task):
+    n_events = luigi.IntParameter()
+    event_type = luigi.Parameter()
+
+    def create_path(self):
+        import modularAnalysis
+
+        path = basf2.create_path()
+
+        modularAnalysis.inputMdstList('default', self.get_input_file_names()["reconstructed_output.root"], path=path)
+
+        modularAnalysis.fillParticleLists([('K+', 'kaonID > 0.1'), ('pi+', 'pionID > 0.1')], path=path)
+
+        modularAnalysis.reconstructDecay('D0 -> K- pi+', '1.7 < M < 1.9', path=path)
+        modularAnalysis.fitVertex('D0', 0.1, path=path)
+        modularAnalysis.matchMCTruth('D0', path=path)
+
+        modularAnalysis.reconstructDecay('B- -> D0 pi-', '5.2 < Mbc < 5.3', path=path)
+        modularAnalysis.fitVertex('B+', 0.1, path=path)
+        modularAnalysis.matchMCTruth('B-', path=path)
+
+        modularAnalysis.variablesToNTuple(
+            'D0',
+            ['M', 'p', 'E', 'useCMSFrame(p)', 'useCMSFrame(E)',
+             'daughter(0, kaonID)', 'daughter(1, pionID)', 'isSignal', 'mcErrors'],
+            filename=self.get_output_file_names()["D_n_tuple.root"],
+            path=path
+        )
+
+        modularAnalysis.variablesToNTuple(
+            'B-',
+            ['Mbc', 'deltaE', 'isSignal', 'mcErrors', 'M'],
+            filename=self.get_output_file_names()["B_n_tuple.root"],
+            path=path
+        )
+
+        return path
+
+    def output(self):
+        yield self.add_to_output("D_n_tuple.root")
+        yield self.add_to_output("B_n_tuple.root")
+
+    def requires(self):
+        return self.clone(ReconstructionTask)
+
+
+class MasterTask(b2luigi.core.helper_tasks.Basf2nTupleMergeTask):
+    n_events = luigi.IntParameter()
+
+    def requires(self):
+        for event_type in ['Y4S', 'Continuum']:
+            yield self.clone(AnalysisTask, event_type=event_type)
+
+
+if __name__ == "__main__":
+    b2luigi.process(MasterTask(n_events=500), workers=4)


### PR DESCRIPTION
This PR contains mainly a example work flow using the b2luigi basf2 tasks to implement a task chain beginning with the simulation of MC, the reconstruction, the online analysis of a simple B decay and the merging of the produced n-tuple files.

The Basf2nTupleMergeTask used in this example workflow is also added to the helper_tasks. It uses the basf2 command fei_merge_files for the merging of the nTuples. This command can handle a large number of input files and can also be used to merge other root files.

Documentation for the example will be added soon.