### PR TITLE
Implemented optional method to define log file paths

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -228,6 +228,9 @@ def create_output_file_name(task, base_filename, create_folder=False, result_pat
 
 
 def get_log_files(task):
+    if hasattr(task, 'get_log_files'):
+        return task.get_log_files()
+
     filename = os.path.realpath(sys.argv[0])
     log_folder = get_setting("log_folder", default=os.path.join(os.path.dirname(filename), "logs"))
     stdout_file_name = create_output_file_name(task, task.get_task_family() + "_stdout", create_folder=True,

--- a/docs/advanced/faq.rst
+++ b/docs/advanced/faq.rst
@@ -3,4 +3,27 @@
 FAQ
 ===
 
-TODO
+Can I specify my own paths for the log files for tasks running on a batch system?
+---------------------------------------------------------------------------------
+
+``b2luigi`` will automatically create log files for the ``stdout`` and ``stderr``
+output of a task processed on a batch system. The paths of these log files are defined
+relative to the location of the executed python file and contain the parameter of
+the task.
+In some cases one might one to specify other paths for the log files. To achieve this,
+a own :meth:`get_log_files()` method of the task class must be implemented. This method
+must return a tuple of the paths for the stdout and the stderr files, for example:
+
+.. code-block:: python
+
+    class MyBatchTask(b2luigi.Task):
+        ...
+        def get_log_files(self):
+            filename = os.path.realpath(sys.argv[0])
+            stdout_path = os.path.join(os.path.dirname(filename), "logs", "simple_stdout")
+            stderr_path = os.path.join(os.path.dirname(filename), "logs", "simple_stderr")
+            return stdout_path, stderr_path
+
+``b2luigi`` will use this method if it is defined and write the log output in the respective
+files. Be careful, though, as these log files will of course be overwritten if more than one
+task receive the same paths to write to!


### PR DESCRIPTION
Implemented optional method to define log file paths for tasks which are processed on a batch system and included instructions on how to use this feature as FAQ entry.