### PR TITLE
Using absolute path of executable in job submission command

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -293,6 +293,6 @@ def create_cmd_from_task(task):
     executable = get_setting("executable", [sys.executable])
     cmd += executable
 
-    cmd += [os.path.basename(filename), "--batch-runner", "--task-id", task.task_id]
+    cmd += [os.path.abspath(filename), "--batch-runner", "--task-id", task.task_id]
 
     return cmd


### PR DESCRIPTION
As the title suggest, this PR changes the job submission command so that the absolute path of the executable is used instead of only its name.