### PR TITLE
Added check if requested task for batch worker exists...

### DIFF
--- a/b2luigi/cli/runner.py
+++ b/b2luigi/cli/runner.py
@@ -11,11 +11,13 @@ from b2luigi.core.utils import task_iterator, get_all_output_files_in_tree
 
 
 def run_as_batch_worker(task_list, cli_args, kwargs):
+    found_task = False
     for root_task in task_list:
         for task in task_iterator(root_task):
             if task.task_id != cli_args.task_id:
                 continue
 
+            found_task = True
             set_setting("local_execution", True)
 
             # TODO: We do not process the information if (a) we have a new dependency and (b) why the task has failed.
@@ -26,6 +28,10 @@ def run_as_batch_worker(task_list, cli_args, kwargs):
             except BaseException as ex:
                 task.on_failure(ex)
                 raise ex
+
+    if not found_task:
+        raise ValueError(f"The task id {task.task_id} to be executed by this batch worker "
+                         f"does not exist in the locally reproduced task graph.")
 
 
 def run_batched(task_list, cli_args, kwargs):

--- a/docs/advanced/faq.rst
+++ b/docs/advanced/faq.rst
@@ -27,3 +27,15 @@ must return a tuple of the paths for the stdout and the stderr files, for exampl
 ``b2luigi`` will use this method if it is defined and write the log output in the respective
 files. Be careful, though, as these log files will of course be overwritten if more than one
 task receive the same paths to write to!
+
+
+What does the ValueError "The task id {task.task_id} to be executed..." mean?
+-----------------------------------------------------------------------------
+
+The `ValueError` exception `The task id <task_id> to be executed by this batch worker does
+not exist in the locally reproduced task graph.` is thrown by ``b2luigi`` batch workers if
+the task that should have been executed by this batch worker does not exist in the task
+graph reproduced by the batch worker. This means that the task graph produced by the initial
+``b2luigi.process`` call and the one reproduced in the batch job differ from each other.
+This can be caused by a non-deterministic behavior of your dependency graph generation, such
+as a random task parameter.


### PR DESCRIPTION
... in locally reproduced dependency graph which will raise an exception if no match for the requested task is found. Also added an FAQ entry which explains this exception.