### PR TITLE
Feature/log files folder

### DIFF
--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 
 from b2luigi.batch.processes import BatchProcess, JobStatus
-from b2luigi.core.utils import get_log_files
+from b2luigi.core.utils import get_log_file_dir
 
 
 class LSFProcess(BatchProcess):
@@ -48,9 +48,10 @@ class LSFProcess(BatchProcess):
         except AttributeError:
             pass
 
-        # Automatic requeing?
+        log_file_dir = get_log_file_dir(self.task)
+        stderr_log_file = log_file_dir + "stderr"
+        stdout_log_file = log_file_dir + "stdout"
 
-        stdout_log_file, stderr_log_file = get_log_files(self.task)
         prefix += ["-eo", stderr_log_file, "-oo", stdout_log_file]
 
         output = subprocess.check_output(prefix + self.task_cmd)

--- a/b2luigi/batch/processes/test.py
+++ b/b2luigi/batch/processes/test.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from b2luigi.batch.processes import BatchProcess, JobStatus
-from b2luigi.core.utils import get_log_files
+from b2luigi.core.utils import get_log_file_dir
 
 
 class TestProcess(BatchProcess):
@@ -24,7 +24,9 @@ class TestProcess(BatchProcess):
             return JobStatus.successful
 
     def start_job(self):
-        stdout_log_file, stderr_log_file = get_log_files(self.task)
+        log_file_dir = get_log_file_dir(self.task)
+        stderr_log_file = log_file_dir + "stderr"
+        stdout_log_file = log_file_dir + "stdout"
 
         with open(stdout_log_file, "w") as stdout:
             with open(stderr_log_file, "w") as stderr:

--- a/b2luigi/core/dispatchable_task.py
+++ b/b2luigi/core/dispatchable_task.py
@@ -5,7 +5,7 @@ import sys
 
 from b2luigi.core.settings import get_setting
 from b2luigi.core.task import Task
-from b2luigi.core.utils import get_log_files, add_on_failure_function, create_cmd_from_task
+from b2luigi.core.utils import get_log_file_dir, add_on_failure_function, create_cmd_from_task
 
 
 def _run_task_locally(task, run_function):
@@ -17,7 +17,9 @@ def _run_task_remote(task):
     add_on_failure_function(task)
 
     filename = os.path.realpath(sys.argv[0])
-    stdout_file_name, stderr_file_name = get_log_files(task)
+    log_file_dir = get_log_file_dir(task)
+    stderr_file_name = log_file_dir + "stderr"
+    stdout_file_name = log_file_dir + "stdout"
 
     cmd = create_cmd_from_task(task)
 

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -267,17 +267,14 @@ def _flatten(struct):
 
 def on_failure(self, exception):
     log_file_dir = get_log_file_dir(self)
-    stderr_file_name = log_file_dir + "stderr"
-    stdout_file_name = log_file_dir + "stdout"
 
     print(colorama.Fore.RED)
     print("Task", self.task_family, "failed!")
     print("Parameters")
     for key, value in self.get_filled_params().items():
         print("\t", key, "=", value)
-    print("Please have a look into the log files")
-    print(stdout_file_name)
-    print(stderr_file_name)
+    print("Please have a look into the log files in ")
+    print(log_file_dir)
     print(colorama.Style.RESET_ALL)
 
 

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -230,19 +230,16 @@ def create_output_file_name(task, base_filename, create_folder=False, result_pat
     return filename
 
 
-def get_log_files(task):
-    if hasattr(task, 'get_log_files'):
-        return task.get_log_files()
+def get_log_file_dir(task):
+    if hasattr(task, 'get_log_file_dir'):
+        log_file_dir = task.get_log_file_dir()
+        return log_file_dir
 
     filename = os.path.realpath(sys.argv[0])
-    log_folder = get_setting("log_folder", default=os.path.join(os.path.dirname(filename), "logs"))
-    stdout_file_name = create_output_file_name(task, task.get_task_family() + "_stdout", create_folder=True,
-                                               result_path=log_folder)
+    base_log_file_dir = get_setting("log_folder", default=os.path.join(os.path.dirname(filename), "logs"))
 
-    stderr_file_name = create_output_file_name(task, task.get_task_family() + "_stderr", create_folder=True,
-                                               result_path=log_folder)
-
-    return stdout_file_name, stderr_file_name
+    log_file_dir = create_output_file_name(task, task.get_task_family() + "/", create_folder=True, result_path=base_log_file_dir)
+    return log_file_dir
 
 
 def _to_dict(d):
@@ -269,7 +266,9 @@ def _flatten(struct):
 
 
 def on_failure(self, exception):
-    stdout_file_name, stderr_file_name = get_log_files(self)
+    log_file_dir = get_log_file_dir(self)
+    stderr_file_name = log_file_dir + "stderr"
+    stdout_file_name = log_file_dir + "stdout"
 
     print(colorama.Fore.RED)
     print("Task", self.task_family, "failed!")

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -273,7 +273,7 @@ def on_failure(self, exception):
     print("Parameters")
     for key, value in self.get_filled_params().items():
         print("\t", key, "=", value)
-    print("Please have a look into the log files in ")
+    print("Please have a look into the log files in")
     print(log_file_dir)
     print(colorama.Style.RESET_ALL)
 

--- a/docs/advanced/faq.rst
+++ b/docs/advanced/faq.rst
@@ -11,18 +11,17 @@ output of a task processed on a batch system. The paths of these log files are d
 relative to the location of the executed python file and contain the parameter of
 the task.
 In some cases one might one to specify other paths for the log files. To achieve this,
-a own :meth:`get_log_files()` method of the task class must be implemented. This method
-must return a tuple of the paths for the stdout and the stderr files, for example:
+a own :meth:`get_log_file_dir()` method of the task class must be implemented. This method
+must return a directory path for the stdout and the stderr files, for example:
 
 .. code-block:: python
 
     class MyBatchTask(b2luigi.Task):
         ...
-        def get_log_files(self):
+        def get_log_file_dir(self):
             filename = os.path.realpath(sys.argv[0])
-            stdout_path = os.path.join(os.path.dirname(filename), "logs", "simple_stdout")
-            stderr_path = os.path.join(os.path.dirname(filename), "logs", "simple_stderr")
-            return stdout_path, stderr_path
+            path = os.path.join(os.path.dirname(filename), "logs")
+            return path
 
 ``b2luigi`` will use this method if it is defined and write the log output in the respective
 files. Be careful, though, as these log files will of course be overwritten if more than one

--- a/tests/batch/test_batch_process.py
+++ b/tests/batch/test_batch_process.py
@@ -16,5 +16,5 @@ class BatchProcessTestCase(B2LuigiTestCase):
         self.assertFalse(os.path.exists("some_parameter=bla_blub/combined.txt"))
 
         self.assertIn(b"Task MyAdditionalTask failed!", out.splitlines())
-        self.assertIn(b"Please have a look into the log files", out.splitlines())
+        self.assertIn(b"Please have a look into the log files in", out.splitlines())
         self.assertIn(b"This progress looks :( because there were failed tasks", out.splitlines())

--- a/tests/core/test_dispatch_task.py
+++ b/tests/core/test_dispatch_task.py
@@ -19,5 +19,5 @@ class DispatchTaskTestCase(B2LuigiTestCase):
                 self.assertEqual(f.readlines(), ["Hello!\n", "Bye!\n"])
 
             self.assertIn(b"Task MyTask failed!", out.splitlines())
-            self.assertIn(b"Please have a look into the log files", out.splitlines())
+            self.assertIn(b"Please have a look into the log files in", out.splitlines())
             self.assertIn(b"RuntimeError: Execution failed with return code -11", out.splitlines())

--- a/tests/core/test_dispatch_task.py
+++ b/tests/core/test_dispatch_task.py
@@ -12,10 +12,10 @@ class DispatchTaskTestCase(B2LuigiTestCase):
 
             self.assertTrue(os.path.exists("results/some_file.txt"))
             self.assertFalse(os.path.exists("results/some_other_file.txt"))
-            self.assertTrue(os.path.exists("logs/MyTask_stderr"))
-            self.assertTrue(os.path.exists("logs/MyTask_stdout"))
+            self.assertTrue(os.path.exists("logs/MyTask/stderr"))
+            self.assertTrue(os.path.exists("logs/MyTask/stdout"))
 
-            with open("logs/MyTask_stdout", "r") as f:
+            with open("logs/MyTask/stdout", "r") as f:
                 self.assertEqual(f.readlines(), ["Hello!\n", "Bye!\n"])
 
             self.assertIn(b"Task MyTask failed!", out.splitlines())

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import b2luigi
 
 from ..helpers import B2LuigiTestCase


### PR DESCRIPTION
Instead of getting the log files directly, better ask for a folder for storing logs.
This makes it easier to add log files dependent on the task itself (e.g. batch jobs may need additional logs).

@FelixMetzner You may have to change your API, sorry!