### PR TITLE
Fix for `get_basf2_git_hash` to work with new tools

### DIFF
--- a/b2luigi/basf2_helper/utils.py
+++ b/b2luigi/basf2_helper/utils.py
@@ -6,7 +6,7 @@ import git
 def get_basf2_git_hash():
     basf2_release = os.getenv("BELLE2_RELEASE")
 
-    if basf2_release == "head":
+    if basf2_release == "head" or basf2_release is None:
         basf2_release_location = os.getenv("BELLE2_LOCAL_DIR")
 
         assert basf2_release_location


### PR DESCRIPTION
With the new BelleII tools, it seems that `$BELLE2_RELEASE` is only set if actually a release is used and is left unset for a development setup, where it head been set to `head` in the past. As a result, I got `None` as a git hash when running this function. I suppose it's no bug in the tools, so one could adapt this function here.