### PR TITLE
Feature/deprecate some settings

### DIFF
--- a/b2luigi/cli/runner.py
+++ b/b2luigi/cli/runner.py
@@ -19,7 +19,7 @@ def run_as_batch_worker(task_list, cli_args, kwargs):
                 continue
 
             found_task = True
-            set_setting("local_execution", True)
+            set_setting("_dispatch_local_execution", True)
 
             # TODO: We do not process the information if (a) we have a new dependency and (b) why the task has failed.
             # TODO: Would be also nice to run the event handlers
@@ -64,7 +64,7 @@ def run_luigi(task_list, cli_args, kwargs):
 
 
 def run_test_mode(task_list, cli_args, kwargs):
-    set_setting("local_execution", True)
+    set_setting("_dispatch_local_execution", True)
     luigi.build(task_list, log_level="DEBUG", local_scheduler=True, **kwargs)
 
 

--- a/b2luigi/core/dispatchable_task.py
+++ b/b2luigi/core/dispatchable_task.py
@@ -50,7 +50,7 @@ def dispatch(run_function):
 
     @functools.wraps(run_function)
     def wrapped_run_function(task):
-        if get_setting("local_execution", False):
+        if get_setting("_dispatch_local_execution", default=False, deprecated_keys=["local_execution"]):
             create_output_dirs(task)
             run_function(task)
         else:

--- a/b2luigi/core/task.py
+++ b/b2luigi/core/task.py
@@ -45,7 +45,7 @@ class Task(luigi.Task):
         This function will automatically add all current parameter values to 
         the file name when used in the form
         
-            result_path/param_1=value/param_2=value/output_file_name
+            result_dir/param_1=value/param_2=value/output_file_name
 
         This function will automatically use a ``LocalTarget``.
         If you do not want this, you can override the :obj:`_get_output_file_target` function.

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -308,7 +308,13 @@ def add_on_failure_function(task):
 def create_cmd_from_task(task):
     filename = os.path.basename(get_filename())
 
-    cmd = get_setting("cmd_prefix", task=task, default=[])
+    prefix = get_setting("executable_prefix", task=task, default=[],
+                         deprecated_keys=["cmd_prefix"])
+
+    if isinstance(prefix, str):
+        raise ValueError("Your specified executable_prefix needs to be a list of strings, e.g. [strace]")
+
+    cmd = prefix
 
     executable = get_setting("executable", task=task, default=[sys.executable])
 

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -221,15 +221,15 @@ def get_serialized_parameters(task):
     return serialized_parameters
 
 
-def create_output_file_name(task, base_filename, result_path=None):
+def create_output_file_name(task, base_filename, result_dir=None):
     serialized_parameters = get_serialized_parameters(task)
 
-    if not result_path:
+    if not result_dir:
         # Be sure to evaluate things relative to the current executed file, not to where we are now
-        result_path = map_folder(get_setting("result_path", task=task, default="."))
+        result_dir = map_folder(get_setting("result_dir", task=task, default=".", deprecated_keys=["result_path"]))
 
     param_list = [f"{key}={value}" for key, value in serialized_parameters.items()]
-    output_path = os.path.join(result_path, *param_list)
+    output_path = os.path.join(result_dir, *param_list)
 
     return os.path.join(output_path, base_filename)
 
@@ -240,8 +240,9 @@ def get_log_file_dir(task):
         return log_file_dir
         
     # Be sure to evaluate things relative to the current executed file, not to where we are now
-    base_log_file_dir = map_folder(get_setting("log_folder", task=task, default="logs"))
-    log_file_dir = create_output_file_name(task, task.get_task_family() + "/", result_path=base_log_file_dir)
+    base_log_file_dir = map_folder(get_setting("log_dir", task=task, default="logs", 
+                                               deprecated_keys=["log_folder"]))
+    log_file_dir = create_output_file_name(task, task.get_task_family() + "/", result_dir=base_log_file_dir)
 
     return log_file_dir
 

--- a/docs/advanced/basf2-examples.rst
+++ b/docs/advanced/basf2-examples.rst
@@ -67,7 +67,7 @@ executable explicitly.
         b2luigi.set_setting("executable", ["python3"])
 
         # Where to store the results
-        b2luigi.set_setting("result_path", "results")
+        b2luigi.set_setting("result_dir", "results")
 
         b2luigi.process(Wrapper(), batch=True, workers=100)
 

--- a/docs/usage/batch.rst
+++ b/docs/usage/batch.rst
@@ -73,7 +73,7 @@ Please checkout the specifics below.
 
 .. hint:: 
 
-    All relative paths given to e.g. the ``result_path`` or the ``log_folder`` are always evaluated 
+    All relative paths given to e.g. the ``result_dir`` or the ``log_dir`` are always evaluated 
     relative to the folder where your script lives.
     To prevent any disambiguities, try to use absolute paths whenever possible.
 

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -137,7 +137,7 @@ Later, we will build the average of those numbers.
 
         .. code-block:: python 
 
-            b2luigi.set_setting("result_path", "results")
+            b2luigi.set_setting("result_dir", "results")
 
         Instead, you can also add a ``settings.json`` with the following content
         in the folder where your script lives:

--- a/tests/core/dispatch_1.py
+++ b/tests/core/dispatch_1.py
@@ -22,5 +22,5 @@ class MyTask(b2luigi.DispatchableTask):
 
 
 if __name__ == "__main__":
-    b2luigi.set_setting("result_path", "results")
+    b2luigi.set_setting("result_dir", "results")
     b2luigi.process(MyTask())

--- a/tests/core/dispatch_2.py
+++ b/tests/core/dispatch_2.py
@@ -23,5 +23,5 @@ class MyTask(b2luigi.Task):
 
 
 if __name__ == "__main__":
-    b2luigi.set_setting("result_path", "results")
+    b2luigi.set_setting("result_dir", "results")
     b2luigi.process(MyTask())

--- a/tests/core/folder_structures.py
+++ b/tests/core/folder_structures.py
@@ -12,5 +12,5 @@ class MyTask(b2luigi.Task):
 
 
 if __name__ == "__main__":
-    b2luigi.set_setting("result_path", "results")
+    b2luigi.set_setting("result_dir", "results")
     b2luigi.process(MyTask())

--- a/tests/core/test_folder_structures.py
+++ b/tests/core/test_folder_structures.py
@@ -6,7 +6,7 @@ import b2luigi
 
 
 class TemporaryWrapperTestCase(B2LuigiTestCase):
-    def test_result_path(self):
+    def test_result_dir(self):
         self.call_file("core/folder_structures.py")
 
         self.assertTrue(os.path.exists("results/test.txt"))
@@ -15,7 +15,7 @@ class TemporaryWrapperTestCase(B2LuigiTestCase):
             self.assertEqual(f.read(), "Test")
 
 
-    def test_result_path_from_other_location(self):
+    def test_result_dir_from_other_location(self):
         os.makedirs("some_other_folder", exist_ok=True)
         self.call_file("core/folder_structures.py", cwd="some_other_folder")
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -15,7 +15,7 @@ class TaskTestCase(B2LuigiTestCase):
         
         task = TaskA(some_parameter=3)
 
-        b2luigi.set_setting("result_path", "results/some_crazy_path")
+        b2luigi.set_setting("result_dir", "results/some_crazy_path")
         
         self.assertEqual(get_filled_params(task), {"some_parameter": 3})
         self.assertFalse(task.get_input_file_names())

--- a/tests/doc_examples/settings.json
+++ b/tests/doc_examples/settings.json
@@ -1,3 +1,3 @@
 {
-	"result_path": "results"
+	"result_dir": "results"
 }

--- a/tests/doc_examples/simple_example.py
+++ b/tests/doc_examples/simple_example.py
@@ -15,6 +15,6 @@ class MyNumberTask(b2luigi.Task):
 
 
 if __name__ == "__main__":
-    b2luigi.set_setting("result_path", "results")
+    b2luigi.set_setting("result_dir", "results")
     b2luigi.process([MyNumberTask(some_parameter=i) for i in range(100)], 
                     workers=200)

--- a/tests/doc_examples/simple_example_b2luigi.py
+++ b/tests/doc_examples/simple_example_b2luigi.py
@@ -16,6 +16,6 @@ class MyNumberTask(b2luigi.Task):
 
 
 if __name__ == "__main__":
-    b2luigi.set_setting("result_path", "results")
+    b2luigi.set_setting("result_dir", "results")
     b2luigi.process([MyNumberTask(some_parameter=i) for i in range(100)],
                      workers=200)

--- a/tests/doc_examples/simple_example_b2luigi_2.py
+++ b/tests/doc_examples/simple_example_b2luigi_2.py
@@ -39,5 +39,5 @@ class MyAverageTask(b2luigi.Task):
 
 
 if __name__ == "__main__":
-    b2luigi.set_setting("result_path", "results")
+    b2luigi.set_setting("result_dir", "results")
     b2luigi.process(MyAverageTask(), workers=200)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,7 @@ class B2LuigiTestCase(TestCase):
         self.cwd = os.getcwd()
         os.chdir(self.test_dir)
 
-        b2luigi.set_setting("result_path", "results")
+        b2luigi.set_setting("result_dir", "results")
 
     def tearDown(self):
         os.chdir(self.cwd)


### PR DESCRIPTION
This PR includes several deprecations of setting names, mostly to make them all follow the same schema.

The setting renamings are:

    cmd_prefix -> executable_prefix
    local_execution -> _dispatch_local_execution
    log_folder -> log_dir
    result_path -> result_dir

The old names are not removed already but will print a deprecation warning on usage. I plan to deprecate then later (maybe next major release).

CC: @welschma @FelixMetzner @elimik31 