### PR TITLE
include task name in directory structure of the created output file name

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -229,7 +229,7 @@ def create_output_file_name(task, base_filename, result_dir=None):
         result_dir = map_folder(get_setting("result_dir", task=task, default=".", deprecated_keys=["result_path"]))
 
     param_list = [f"{key}={value}" for key, value in serialized_parameters.items()]
-    output_path = os.path.join(result_dir, *param_list)
+    output_path = os.path.join(result_dir, task.get_task_family(), *param_list)
 
     return os.path.join(output_path, base_filename)
 


### PR DESCRIPTION
If applied, this commit will include task name in directory structure of the created output file name.

At the moment, the structure of the results directory only depends on the task parameters but not the task (names) itself. This change will add the task name before the parameter list.