### PR TITLE
Adding option for user-defined get_task_file_dir

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -9,7 +9,8 @@ import types
 
 import colorama
 
-from b2luigi.core.settings import set_setting, get_setting
+from b2luigi.core.settings import get_setting
+
 
 @contextlib.contextmanager
 def remember_cwd():
@@ -238,9 +239,9 @@ def get_log_file_dir(task):
     if hasattr(task, 'get_log_file_dir'):
         log_file_dir = task.get_log_file_dir()
         return log_file_dir
-        
+
     # Be sure to evaluate things relative to the current executed file, not to where we are now
-    base_log_file_dir = map_folder(get_setting("log_dir", task=task, default="logs", 
+    base_log_file_dir = map_folder(get_setting("log_dir", task=task, default="logs",
                                                deprecated_keys=["log_folder"]))
     log_file_dir = create_output_file_name(task, task.get_task_family() + "/", result_dir=base_log_file_dir)
 
@@ -248,6 +249,10 @@ def get_log_file_dir(task):
 
 
 def get_task_file_dir(task):
+    if hasattr(task, 'get_task_file_dir'):
+        task_file_dir = task.get_task_file_dir()
+        return task_file_dir
+
     task_file_dir = create_output_file_name(task, task.get_task_family() + "/")
 
     return task_file_dir
@@ -258,6 +263,7 @@ def get_filename():
     filename = __main__.__file__
 
     return filename
+
 
 def map_folder(input_folder):
     filename = get_filename()


### PR DESCRIPTION
This PR introduces the option to also provide a user-defined directory for the task executable via `get_task_file_dir` analog to the option provided for `get_log_file_dir`.

If a task defines the method `get_task_file_dir` the return value of this method will be interpreted as path to the directory to be used for the location of the executable file.

I also thought about using one optional task method such as `get_task_working_dir` to be used in both, the `get_log_file_dir` and the `get_task_file_dir`, but refrained from doing so, because this directory does not necessarily have to be the working directory. In my use case this directory only contains information for and about the task execution on the LSF batch system. For the htcondor case the directory fulfills a  more important purpose.

If you have suggestions for improvements, please let me know.