### PR TITLE
When creating output file names, escape forward slashes by dots

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -230,7 +230,8 @@ def create_output_file_name(task, base_filename, result_dir=None):
         result_dir = map_folder(get_setting("result_dir", task=task, default=".", deprecated_keys=["result_path"]))
 
     param_list = [f"{key}={value}" for key, value in serialized_parameters.items()]
-    output_path = os.path.join(result_dir, *param_list)
+    excaped_param_list = [param.replace("/", ".") for param in param_list]
+    output_path = os.path.join(result_dir, *excaped_param_list)
 
     return os.path.join(output_path, base_filename)
 


### PR DESCRIPTION
When a luigi parameter contains slashes, e.g. when it is a path, additional
subdirectories for each substring between the slashes in the parameter are created. It actually does not break anything, because the getting and creating of filenames is still symmetric. I am not sure what the best way to escape the path is, I chose dots but can change that if you prefer something else.

Found that when I used b2luigi to send gbasf2 jobs and passed grid datasets as a parameter and was surprised by the output directory structure.