### PR TITLE
Feature/warning if forward slash in parameter

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -6,6 +6,7 @@ import os
 import collections
 import sys
 import types
+import warnings
 
 import colorama
 
@@ -228,6 +229,12 @@ def create_output_file_name(task, base_filename, result_dir=None):
     if not result_dir:
         # Be sure to evaluate things relative to the current executed file, not to where we are now
         result_dir = map_folder(get_setting("result_dir", task=task, default=".", deprecated_keys=["result_path"]))
+
+    for key, value in serialized_parameters.items():
+        if "/" in value:
+           warnings.warn(f"Value of parameter ``{key}`` contains forward slash '/'. "
+                         "This will result in an additional subdirectory in the output path. "
+                         "Consider using a hashed parameter (e.g. ``b2luigi.Parameter(hashed=True)``)")
 
     param_list = [f"{key}={value}" for key, value in serialized_parameters.items()]
     output_path = os.path.join(result_dir, *param_list)

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -231,10 +231,10 @@ def create_output_file_name(task, base_filename, result_dir=None):
         result_dir = map_folder(get_setting("result_dir", task=task, default=".", deprecated_keys=["result_path"]))
 
     for key, value in serialized_parameters.items():
-        if "/" in value:
-           warnings.warn(f"Value of parameter ``{key}`` contains forward slash '/'. "
-                         "This will result in an additional subdirectory in the output path. "
-                         "Consider using a hashed parameter (e.g. ``b2luigi.Parameter(hashed=True)``)")
+        if isinstance(key, str) and "/" in value:
+            warnings.warn(f"Value of parameter ``{key}`` contains forward slash \"/\". "
+                          "This will result in an additional subdirectory in the output path. "
+                          "Consider using a hashed parameter (e.g. ``b2luigi.Parameter(hashed=True)``)")
 
     param_list = [f"{key}={value}" for key, value in serialized_parameters.items()]
     output_path = os.path.join(result_dir, *param_list)


### PR DESCRIPTION
Print a warning suggesting to use hashed parameters when a luigi parameter value has a forward slash, as this will split the output path in multiple directories corresponding to the substrings on both sides of the slash. Not an Exception, as b2luigi will still work.

The warning is issued in `create_output_file_name` so that people only see it if they use the `get_output_file_name` utilities of b2luigi.

Related to https://github.com/nils-braun/b2luigi/pull/26