### PR TITLE
Fixing issue in core.utils.get_filename() arising in jupyter notebook

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -266,8 +266,11 @@ def get_task_file_dir(task):
 
 
 def get_filename():
-    import __main__
-    filename = __main__.__file__
+    try:
+      import __main__
+      filename = __main__.__file__
+    except AttributeError as err:
+      filename = sys.argv[0]
 
     return filename
 

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -266,17 +266,24 @@ def get_task_file_dir(task):
 
 
 def get_filename():
-    try:
-      import __main__
-      filename = __main__.__file__
-    except AttributeError as err:
-      filename = sys.argv[0]
-
-    return filename
+    import __main__
+    return __main__.__file__
 
 
 def map_folder(input_folder):
-    filename = get_filename()
+    if os.path.isabs(input_folder):
+      return input_folder
+
+    try:
+      filename = get_filename()
+    except AttributeError as ex:
+      raise type(ex)(
+        "Could not determine the current script location. "
+        "If you are running in an interactive shell (such as jupyter notebook) "
+        "make sure to only provide absolute paths in your settings.\nMore Info:\n"
+        + ex.message
+      ).with_traceback(sys.exc_info()[2])
+
     filepath = os.path.dirname(filename)
 
     return os.path.join(filepath, input_folder)


### PR DESCRIPTION
Hey Nils,

I have been running older jupyter notebooks, which use `b2luigi.core.utils.get_all_output_files_in_tree` to recover the output files created from by a given task. When doing this in a notebook, `b2luigi.core.utils.get_filename` will through an `AttributeError: module '__main__' has no attribute '__file__'`.
I have added a `try`-`except` which catches this and reverts to the old approach using `sys.argv[0]` to get the file name. In case of the notebook this avoids the Error, but does not actually affect the outcome, as the value returned by `sys.argv[0]`will be ignored in the `os.path.join` in the`map_folder` call in `b2luigi.core.utils.create_output_file_name`, where the value returned by `get_setting` will be used. So, maybe one can return something else than `sys.argv[0]` when the `AttributeError' is caught.

Anyway, catching the exception does the trick, when we still want this functionality to work. If you prefer something other than `sys.argv[0]` to be returned in this case, let me know and I will change and test it.

Cheers,

Felix