### PR TITLE
Support renamed fei file merge command for merger task

### DIFF
--- a/b2luigi/basf2_helper/tasks.py
+++ b/b2luigi/basf2_helper/tasks.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import shutil
 
 import b2luigi
 from b2luigi.basf2_helper.targets import ROOTLocalTarget
@@ -114,4 +115,9 @@ class Basf2FileMergeTask(MergerTask):
 
 
 class Basf2nTupleMergeTask(MergerTask):
-    cmd = ["fei_merge_files"]
+    # Define the command to use to merge basf2 output files. Because
+    # ``fei_merge_files`` has been renamed to ``analysis-fei-mergefiles``, use
+    # the newer command if it exists in the release.
+    _new_cmd = ["analysis-fei-mergefiles"]
+    _old_cmd = ["fei_merge_files"]
+    cmd = _new_cmd if shutil.which(_new_cmd) else _old_cmd

--- a/b2luigi/basf2_helper/tasks.py
+++ b/b2luigi/basf2_helper/tasks.py
@@ -118,6 +118,6 @@ class Basf2nTupleMergeTask(MergerTask):
     # Define the command to use to merge basf2 output files. Because
     # ``fei_merge_files`` has been renamed to ``analysis-fei-mergefiles``, use
     # the newer command if it exists in the release.
-    _new_cmd = ["analysis-fei-mergefiles"]
-    _old_cmd = ["fei_merge_files"]
-    cmd = _new_cmd if shutil.which(_new_cmd) else _old_cmd
+    _new_cmd_name = "analysis-fei-mergefiles"
+    _old_cmd_name = "fei_merge_files"
+    cmd = [_new_cmd_name] if shutil.which(_new_cmd_name) else [_old_cmd_name]

--- a/b2luigi/basf2_helper/tasks.py
+++ b/b2luigi/basf2_helper/tasks.py
@@ -115,9 +115,13 @@ class Basf2FileMergeTask(MergerTask):
 
 
 class Basf2nTupleMergeTask(MergerTask):
-    # Define the command to use to merge basf2 output files. Because
-    # ``fei_merge_files`` has been renamed to ``analysis-fei-mergefiles``, use
-    # the newer command if it exists in the release.
-    _new_cmd_name = "analysis-fei-mergefiles"
-    _old_cmd_name = "fei_merge_files"
-    cmd = [_new_cmd_name] if shutil.which(_new_cmd_name) else [_old_cmd_name]
+    @property
+    def cmd(self):
+        "Command to use to merge basf2 tuple files."
+        # ``fei_merge_files`` has been renamed to ``analysis-fei-mergefiles``, use
+        # the newer command if it exists in the release.
+        new_cmd_name = "analysis-fei-mergefiles"
+        old_cmd_name = "fei_merge_files"
+        if shutil.which(new_cmd_name):
+            return [new_cmd_name]
+        return [old_cmd_name]


### PR DESCRIPTION
In the PR
https://stash.desy.de/projects/B2/repos/software/pull-requests/6174/overview
the command fei_merge_files has been rename to analysis-fei-mergefiles. The old
command still works, but gives a deprecation warning. Therefore, we first try
the new command and if it doesn't exist the old command.

Alternative implementation ideas:
- Use a property function for `cmd` and put the logic which command exists into the function body.
- At the moment I only call `shutil.which` for the new command, for the old command I don't check it and just except that the subprocess call in the base class will fail later. Maybe I could check for both commands if they exist and if neither does, raise an exception. (`FileNotFoundError`?)