### PR TITLE
Update vertex fit in basf2 example to work for release 4 and new light releases

### DIFF
--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -7,6 +7,7 @@ import basf2
 
 import modularAnalysis
 import simulation
+import vertex
 import generators
 import reconstruction
 from ROOT import Belle2
@@ -68,10 +69,12 @@ class AnalysisTask(Basf2PathTask):
         modularAnalysis.inputMdstList('default', self.get_input_file_names("reconstructed_output.root"), path=path)
         modularAnalysis.fillParticleLists([('K+', 'kaonID > 0.1'), ('pi+', 'pionID > 0.1')], path=path)
         modularAnalysis.reconstructDecay('D0 -> K- pi+', '1.7 < M < 1.9', path=path)
-        modularAnalysis.fitVertex('D0', 0.1, path=path)
         modularAnalysis.matchMCTruth('D0', path=path)
         modularAnalysis.reconstructDecay('B- -> D0 pi-', '5.2 < Mbc < 5.3', path=path)
-        modularAnalysis.fitVertex('B+', 0.1, path=path)
+        try:  # treeFit is the new function name in light releases after release 4 (e.g. light-2002-janus)
+            vertex.treeFit('B+', 0.1, update_all_daughters=True, path=path)
+        except AttributeError:  # vertexTree is the function name in release 4
+            vertex.vertexTree('B+', 0.1, update_all_daughters=True, path=path)
         modularAnalysis.matchMCTruth('B-', path=path)
         modularAnalysis.variablesToNtuple('D0',
                                           ['M', 'p', 'E', 'useCMSFrame(p)', 'useCMSFrame(E)',


### PR DESCRIPTION
`modularAnalysis.fitVertex` has been moved to `vertex.fitVertex` in release 4,
but that is not recommended to be used anymore. Instead, it is recommended to
use the new vertex fitter which is called `vertex.vertexTree` in release 4 and
then has been renamed to `vertex.treeFit` in the light releases following release
4 (i.e. light-2002-janus). It also performs vertex fits for all daughter decays.

The docstring of `vertex.fitVertex` says:
> Direct use of `fitVertex` is not recommended unless you know what you are doing.
> If you're unsure, you probably want to use `treeFit` or `kFit`.

So I decided to use `treeFit` with a try/except clause to enable both current versions,
depending on whether release 4 or light release of it is used. I have tested that my version of the example file no runs without failing, but didn't look at any physics plots. So I would be glad if this could be  @welschma  or @FelixMetzner could check that it makes sense physics-wise.

**Edit**: I just realized that the light releases don't include the simulation/reconstruction packages, so supporting them isn't really important as of now, but we can expect that the new function name will be used in future major releases >= 5.