### PR TITLE
Look for Y4S dec file in new location for rel 5 / master

### DIFF
--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -7,6 +7,7 @@ import basf2
 
 import modularAnalysis
 import simulation
+import vertex
 import generators
 import reconstruction
 from ROOT import Belle2
@@ -26,7 +27,10 @@ class SimulationTask(Basf2PathTask):
         modularAnalysis.setupEventInfo(self.n_events, path)
 
         if self.event_type == SimulationType.y4s:
-            dec_file = Belle2.FileSystem.findFile('analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec')
+            # in current master and release 5 the Y(4S)decay file is moved, so try old and new locations
+            find_file_ignore_error = True
+            dec_file = Belle2.FileSystem.findFile('analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec',
+                                                  find_file_ignore_error)
             if not dec_file:
                 dec_file = Belle2.FileSystem.findFile('analysis/examples/simulations/B2A101-Y4SEventGeneration.dec')
         elif self.event_type == SimulationType.continuum:

--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -27,6 +27,8 @@ class SimulationTask(Basf2PathTask):
 
         if self.event_type == SimulationType.y4s:
             dec_file = Belle2.FileSystem.findFile('analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec')
+            if not dec_file:
+                dec_file = Belle2.FileSystem.findFile('analysis/examples/simulations/B2A101-Y4SEventGeneration.dec')
         elif self.event_type == SimulationType.continuum:
             dec_file = Belle2.FileSystem.findFile('analysis/examples/simulations/B2A102-ccbarEventGeneration.dec')
         else:


### PR DESCRIPTION
The old location `analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec` didn't work for me when I tested the example on the current master, I checked and saw that the location was changed, so I added some code to try both the old and the new location.

Sorry for the many commits, I just wanted to test the ntuple merger task with the changes from my merge-command rename PR https://github.com/nils-braun/b2luigi/pull/36 and testing failed due to basf2 changes.