### PR TITLE
Change default branch to main

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@ b2luigi
            :target: https://b2luigi.readthedocs.io/en/stable/
 .. image:: https://badge.fury.io/py/b2luigi.svg
            :target: https://badge.fury.io/py/b2luigi
-.. image:: https://coveralls.io/repos/github/nils-braun/b2luigi/badge.svg?branch=master
-           :target: https://coveralls.io/github/nils-braun/b2luigi?branch=master
-.. image:: https://travis-ci.org/nils-braun/b2luigi.svg?branch=master
+.. image:: https://coveralls.io/repos/github/nils-braun/b2luigi/badge.svg?branch=main
+           :target: https://coveralls.io/github/nils-braun/b2luigi?branch=main
+.. image:: https://travis-ci.org/nils-braun/b2luigi.svg?branch=main
            :target: https://travis-ci.org/nils-braun/b2luigi
 
 

--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -36,7 +36,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
         flit install -s
 
-4.  The documentation is hosted on read the docs and build automatically on every commit to master.
+4.  The documentation is hosted on read the docs and build automatically on every commit to main.
     You can (and should) also build the documentation locally by installing ``sphinx``
 
     .. code-block:: bash
@@ -55,7 +55,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
 5.  If you are a core developer and want to release a new version:
 
-    a.  Make sure all changes are committed and merged on master
+    a.  Make sure all changes are committed and merged on main
     b.  Use the ``bumpversion`` package to update the version in the python file ``b2luigi/__init__.py`` as well
         as the git tag. ``flit`` will automatically use this.
 

--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -27,7 +27,7 @@ class SimulationTask(Basf2PathTask):
         modularAnalysis.setupEventInfo(self.n_events, path)
 
         if self.event_type == SimulationType.y4s:
-            # in current master and release 5 the Y(4S)decay file is moved, so try old and new locations
+            # in current main branch and release 5 the Y(4S)decay file is moved, so try old and new locations
             find_file_ignore_error = True
             dec_file = Belle2.FileSystem.findFile('analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec',
                                                   find_file_ignore_error)

--- a/examples/gbasf2/gbasf2_example.py
+++ b/examples/gbasf2/gbasf2_example.py
@@ -50,6 +50,6 @@ class MasterTask(b2luigi.WrapperTask):
 
 
 if __name__ == '__main__':
-    master_task_instance = MasterTask()
-    n_gbasf2_tasks = len(list(master_task_instance.requires()))
-    b2luigi.process(master_task_instance, workers=n_gbasf2_tasks)
+    main_task_instance = MasterTask()
+    n_gbasf2_tasks = len(list(main_task_instance.requires()))
+    b2luigi.process(main_task_instance, workers=n_gbasf2_tasks)


### PR DESCRIPTION
This is not a pull request in the real sense, as the main branch will be the new default branch for b2luigi.
GitHub will change its default branch from "master" to "main" in the [near future](https://www.bbc.com/news/technology-53050955).

Probably, you will not notice that much - other than if you do a `git pull` on the former master branch.
You can easily just "git checkout main" after a pull to switch to the new branch.

This PR is to inform the recent contributors, @meliache @FelixMetzner @welschma 
If you have a question, feel free to contact me!