### PR TITLE
Support aliases in gbasf2 batch

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -538,8 +538,12 @@ class Gbasf2Process(BatchProcess):
                         shutil.rmtree(output_dir_path)
                     shutil.move(src=tmp_output_dir, dst=output_dir_path)
                 else:
-                    raise RuntimeError(f"The downloaded of files in {tmp_output_dir} is not equal to the "
-                                       f"dataset files for the grid project {self.gbasf2_project_name}")
+                    raise RuntimeError(
+                        f"The downloaded set of files in {tmp_output_dir} is not equal to the " +
+                        f"list of dataset files on the grid for project {self.gbasf2_project_name}." +
+                        "\nDownloaded files:\n{}".format("\n".join(downloaded_dataset_basenames)) +
+                        "\nFiles on the grid:\n{}".format("\n".join(output_dataset_basenames))
+                    )
 
     def _download_logs(self):
         """

--- a/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
+++ b/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
@@ -1,0 +1,31 @@
+import pickle
+
+from basf2.pickle_path import serialize_path
+from variables import variables as vm
+
+
+def get_alias_dict_from_variable_manager():
+    """
+    Extracts a dictionary with the alias names as keys and their values from the
+    internal state of the variable manager and returns it.
+    """
+    alias_dictionary = {alias_name: vm.getVariable(alias_name).name for alias_name in list(vm.getAliasNames())}
+    return alias_dictionary
+
+
+def write_path_and_aliases_to_file(basf2_path, file_path):
+    """
+    Serialize basf2 path and variables from variable manage to file
+
+    Variant of ``basf2.pickle_path.write_path_to_file``, only with additional
+    serialization of the basf2 variable aliases.  The aliases are extracted from
+    the current state of the variable manager singleton and thus have to be
+    added in the python/basf2 process before calling this function.
+
+    :param path: Basf2 path object to serialize
+    :param file_path: File path to write the serialized pickle object to.
+    """
+    with open(file_path, 'bw') as pickle_file:
+        serialized = serialize_path(basf2_path)
+        serialized["aliases"] = get_alias_dict_from_variable_manager()
+        pickle.dump(serialized, pickle_file)

--- a/b2luigi/batch/processes/templates/gbasf2_steering_file_wrapper.jinja2
+++ b/b2luigi/batch/processes/templates/gbasf2_steering_file_wrapper.jinja2
@@ -1,7 +1,41 @@
 #!/usr/bin/env python3
+import os
+import pickle
+
 import basf2
 from basf2 import pickle_path as b2pp
-path = b2pp.get_path_from_file("{{ pickle_file_path }}")
+from variables import variables as vm
+
+
+def get_alias_dict_from_file(file_path):
+    """
+    Returns alias dictionary from pickle file.  If no aliases are stored in the
+    pickle file, returns an empty dictionary.
+    """
+    with open(file_path, 'br') as pickle_file:
+        serialized = pickle.load(pickle_file)
+    try:
+        return serialized["aliases"]
+    except KeyError:
+        return {}
+
+
+def apply_alias_dict_from_file(file_path):
+    """
+    Extract alias dictionary from pickle file and adds them to the variable manager
+    """
+    alias_dict = get_alias_dict_from_file(file_path)
+    for alias_name, alias_value in alias_dict.items():
+        vm.addAlias(alias_name, alias_value)
+
+
+pickle_file_path = "{{ pickle_file_path }}"
+if not os.path.isfile(pickle_file_path):
+    raise FileNotFoundError(f"No pickle file found in {pickle_file_path}")
+
+apply_alias_dict_from_file(pickle_file_path)
+path = b2pp.get_path_from_file(pickle_file_path)
+
 basf2.print_path(path)
 basf2.process(path, max_event={{ max_event }})
 print(basf2.statistics)

--- a/examples/gbasf2/example_mdst_analysis.py
+++ b/examples/gbasf2/example_mdst_analysis.py
@@ -8,6 +8,7 @@ import basf2
 import modularAnalysis as mA
 import vertex as vx
 from stdCharged import stdK, stdPi
+from variables import variables as vm
 
 
 def create_analysis_path(
@@ -40,7 +41,9 @@ def create_analysis_path(
         vx.vertexTree('B+', 0.1, path=path)
     mA.setAnalysisConfigParams({"mcMatchingVersion": "BelleII"}, path)
     mA.matchMCTruth('B-', path=path)
-    mA.variablesToNtuple('D0:Kpi', ['M', 'p', 'E', 'useCMSFrame(p)', 'useCMSFrame(E)', 'daughter(0, kaonID)',
+    vm.addAlias("p_cms", "useCMSFrame(p)")  # include aliases to test if they work
+    vm.addAlias("E_cms", "useCMSFrame(E)")
+    mA.variablesToNtuple('D0:Kpi', ['M', 'p', 'E', 'E_cms', 'p_cms', 'daughter(0, kaonID)',
                                     'daughter(1, pionID)', 'isSignal', 'mcErrors'],
                          filename=d_ntuple_filename, treename="D", path=path)
     mA.variablesToNtuple('B-', ['Mbc', 'deltaE', 'isSignal', 'mcErrors', 'M'],


### PR DESCRIPTION
Sam Cunliffe was so nice to tell me how to extract alias values, not just their names, from the variable manager ([b2question link](https://questions.belle2.org/question/8456/access-alias-values-in-variablemanager-from-python/). With that it was pretty easy to store them also in the pickle and reapply them on the grid. I tested it and it seems to work nicely.

I now you suggested to look at `pickable_basf2.py` to store the basf2 calls, but the variables wouldn't be pickled as far as I know except if you wrap them in `make_code_pickable`. And to be honest I couldn't figure out yet how to use the code from `pickable_basf2` for my use-case yet.