### PR TITLE
Use full grid paths in gbasf2 output queries to avoid gbasf2 bug

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -501,7 +501,8 @@ class Gbasf2Process(BatchProcess):
 
             # Get list of files that we want to download from the grid via ``gb2_ds_list`` so that we can
             # then compare this list with the results of the download to see if it was successful
-            dataset_query_string = f"--user {self.dirac_user} {self.gbasf2_project_name}/{output_file_stem}_*{output_file_ext}"
+            dataset_query_string = \
+                f"/belle/user/{self.dirac_user}/{self.gbasf2_project_name}/{output_file_stem}_*{output_file_ext}"
             ds_list_command = shlex.split(f"gb2_ds_list {dataset_query_string}")
             output_dataset_grid_filepaths = run_with_gbasf2(ds_list_command, capture_output=True).stdout.splitlines()
             output_dataset_basenames = {os.path.basename(grid_path) for grid_path in output_dataset_grid_filepaths}


### PR DESCRIPTION
When testing my added support for basf2 variables on the grid, that my check for the success of the download failed and it turned out that in the new default gbasf2 release, the command `gb2_ds_list` (similar to `ls`, but on the grid) returned total garbage to stdout when used with with wildcard. The thing is, my wrapper uses something like
```
gb2_ds_get --user meliache 'luigiAliasExample55076644b3/D_ntuple_*.root'
```
to download the data for a certain output type and it compare the downloaded files with the output  of
```
gb2_ds_list --user meliache 'luigiAliasExample55076644b3/D_ntuple_*.root'
```
to check that all files had been downloaded. However, the latter command stopped working in the current release. But wildcards still work with absolute grid paths (LFNs). When you don't give an absolute paths, gbasf2 automatically searches in `/belle/user/<username>`. So I worked around the bug by using e.g.
```
gb2_ds_list '/belle/user/luigiAliasExample55076644b3/D_ntuple_*.root'
```
and that seems to work for now.