### PR TITLE
Bugfix: Fix logic in setting gbasf2_additional_params

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -446,7 +446,7 @@ class Gbasf2Process(BatchProcess):
 
         # optional string of additional parameters to append to gbasf2 command
         gbasf2_additional_params = get_setting("gbasf2_additional_params", default=False, task=self.task)
-        if basf2opt is not False:
+        if gbasf2_additional_params is not False:
             gbasf2_command_str += f" {gbasf2_additional_params} "
 
         gbasf2_command = shlex.split(gbasf2_command_str)

--- a/b2luigi/core/parameter.py
+++ b/b2luigi/core/parameter.py
@@ -23,7 +23,7 @@ def wrap_parameter():
 
     old_init = parameter_class.__init__
 
-    def __init__(self, hashed=False, *args,  **kwargs):
+    def __init__(self, hashed=False, *args, **kwargs):
         old_init(self, *args, **kwargs)
 
         if hashed:


### PR DESCRIPTION
The intended functionality is that the value of the setting `gbasf2_additional_params` should be added to the gbasf2
submit command string only if the setting deviates from its default value which
is `False`. I had this pattern for multiple settings and here I had introduced a
copypaste error where whether I accidentally checked for the value of the `basf2opt` setting instead of the this setting.

This can obviously lead to weird behavior, but I must admit I hadn't much used either of the settings yet. I'm surprised this went unnoticed for so long. Thanks for @welschma for finding this.