### PR TITLE
Allow dashes and underscores in gbasf2 project names

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -823,14 +823,13 @@ def get_unique_project_name(task):
     # Only alphanumeric characters (letters and numbers) are officially
     # supported by gbasf2, but we also allow for dashes and underscores, which
     # are widely used by users and increase readability of gbasf2 project names
-    # and seem to work at the moment. \w matches alphanumeric words and
-    # underscores, so [^\w-] matches characters which are neither those nor have
-    # dashes
-    if re.match(r"[^\w-]", gbasf2_project_name):
+    # and seem to work at the moment.
+    valid_project_name_regex_str = r"^[a-zA-Z0-9_-]*$"
+    if not re.match(valid_project_name_regex_str, gbasf2_project_name):
         raise ValueError("Only alphanumeric project names are officially supported by gbasf2")
     if not gbasf2_project_name.isalnum():
         warnings.warn(
-            f"Non-alphanumeric characters (e.g. \"-\" or \"_\") are used in project name \"{gbasf2_project_name}\""
+            f"Non-alphanumeric characters (e.g. \"-\" or \"_\") are used in project name \"{gbasf2_project_name}\". "
             "They are not officially supported by the gbasf2 developers and those are not guaranteed to work"
         )
     return gbasf2_project_name

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -820,19 +820,11 @@ def get_unique_project_name(task):
             f"{max_project_name_length - len(task_id_hash)} characters,"
             f" since the unique task id hash takes {len(task_id_hash)} characters."
         )
-    # Only alphanumeric characters (letters and numbers) are officially
-    # supported by gbasf2, but we also allow for dashes and underscores, which
-    # are widely used by users and increase readability of gbasf2 project names
-    # and seem to work at the moment.
+    # Only alphanumeric characters (letters, numbers and `_`, `-`) are supported by gbasf2
     valid_project_name_regex_str = r"^[a-zA-Z0-9_-]*$"
     if not re.match(valid_project_name_regex_str, gbasf2_project_name):
         raise ValueError(
             f"Project name \"{gbasf2_project_name}\" is invalid. "
             "Only alphanumeric project names are officially supported by gbasf2."
-        )
-    if "-" in gbasf2_project_name or "_" in gbasf2_project_name:
-        warnings.warn(
-            f"The characters \"-\" or \"_\" are used in the project name \"{gbasf2_project_name}\". "
-            "They are not officially supported by the gbasf2 developers and those are not guaranteed to work."
         )
     return gbasf2_project_name

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -1,15 +1,16 @@
 import hashlib
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
 import tempfile
 import warnings
 from collections import Counter
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from functools import lru_cache
-import re
 
 from b2luigi.basf2_helper.utils import get_basf2_git_hash
 from b2luigi.batch.processes import BatchProcess, JobStatus
@@ -399,8 +400,9 @@ class Gbasf2Process(BatchProcess):
         """
         gbasf2_release = get_setting("gbasf2_release", default=get_basf2_git_hash(), task=self.task)
         gbasf2_additional_files = get_setting("gbasf2_additional_files", default=[], task=self.task)
-        assert not isinstance(gbasf2_additional_files, str), "gbasf2_additional_files should be a list or tuple, not a string."
-        gbasf2_input_sandbox_files = [os.path.basename(self.pickle_file_path)] + gbasf2_additional_files
+        if not isinstance(gbasf2_additional_files, Iterable) or isinstance(gbasf2_additional_files, str):
+            raise ValueError("``gbasf2_additional_files`` is not an iterable or strings.")
+        gbasf2_input_sandbox_files = [os.path.basename(self.pickle_file_path)] + list(gbasf2_additional_files)
         gbasf2_command_str = (f"gbasf2 {self.wrapper_file_path} -f {' '.join(gbasf2_input_sandbox_files)} " +
                               f"-p {self.gbasf2_project_name} -s {gbasf2_release} ")
 
@@ -432,7 +434,8 @@ class Gbasf2Process(BatchProcess):
         # gbasf2 job priority
         priority = get_setting("gbasf2_priority", default=False, task=self.task)
         if priority is not False:
-            assert 0 <= priority <= 10, "Priority should be integer between 0 and 10."
+            if not (0 <= priority <= 10):
+                raise ValueError("Priority should be integer between 0 and 10.")
             gbasf2_command_str += f" --priority {priority} "
 
         # gbasf2 job type (e.g. User, Production, ...)
@@ -503,7 +506,11 @@ class Gbasf2Process(BatchProcess):
             output_dir_path = output_target.path
             assert output_file_name == os.path.basename(output_file_name)  # not sure I need this
             output_file_stem, output_file_ext = os.path.splitext(output_file_name)
-            assert output_file_ext == ".root", "gbasf2 batch only supports root outputs"
+            if not output_file_ext == ".root":
+                raise ValueError(
+                    f"Output file name \"{output_file_name}\" does not end with \".root\", "
+                    "but gbasf2 batch only supports root outputs"
+                )
 
             # Get list of files that we want to download from the grid via ``gb2_ds_list`` so that we can
             # then compare this list with the results of the download to see if it was successful
@@ -657,8 +664,10 @@ def get_gbasf2_project_job_status_dict(gbasf2_project_name, dirac_user=None):
     """
     if dirac_user is None:
         dirac_user = get_dirac_user()
-    assert check_project_exists(gbasf2_project_name, dirac_user), \
-        f"Project {gbasf2_project_name} doest not exist yet"
+    if not check_project_exists(gbasf2_project_name, dirac_user):
+        raise RuntimeError(
+            f"Failed to acces job status for project \"{gbasf2_project_name}\" doest not exist on the grid."
+        )
     job_status_script_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                           "gbasf2_utils/gbasf2_job_status.py")
     job_status_command = shlex.split(f"python2 {job_status_script_path} -p {gbasf2_project_name} --user {dirac_user}")
@@ -802,11 +811,14 @@ def get_unique_project_name(task):
     task_id_hash = hashlib.md5(task.task_id.encode()).hexdigest()[0:10]
     gbasf2_project_name = gbasf2_project_name_prefix + task_id_hash
     max_project_name_length = 32
-    assert len(gbasf2_project_name) <= max_project_name_length,\
-        f"Maximum length of project name should be {max_project_name_length}, " + \
-        f"but has {len(gbasf2_project_name)} chars." + \
-        f"Please choose a gbasf2_project_name_prefix of less than {max_project_name_length - len(task_id_hash)} characters," + \
-        f" since the unique task id hash takes {len(task_id_hash)} characters."
+    if len(gbasf2_project_name) > max_project_name_length:
+        raise ValueError(
+            f"Maximum length of project name should be {max_project_name_length}, "
+            f"but has {len(gbasf2_project_name)} chars."
+            "Please choose a gbasf2_project_name_prefix of less than "
+            f"{max_project_name_length - len(task_id_hash)} characters,"
+            f" since the unique task id hash takes {len(task_id_hash)} characters."
+        )
     # Only alphanumeric characters (letters and numbers) are officially
     # supported by gbasf2, but we also allow for dashes and underscores, which
     # are widely used by users and increase readability of gbasf2 project names

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -826,10 +826,13 @@ def get_unique_project_name(task):
     # and seem to work at the moment.
     valid_project_name_regex_str = r"^[a-zA-Z0-9_-]*$"
     if not re.match(valid_project_name_regex_str, gbasf2_project_name):
-        raise ValueError("Only alphanumeric project names are officially supported by gbasf2")
-    if not gbasf2_project_name.isalnum():
+        raise ValueError(
+            f"Project name \"{gbasf2_project_name}\" is invalid. "
+            "Only alphanumeric project names are officially supported by gbasf2."
+        )
+    if "-" in gbasf2_project_name or "_" in gbasf2_project_name:
         warnings.warn(
-            f"Non-alphanumeric characters (e.g. \"-\" or \"_\") are used in project name \"{gbasf2_project_name}\". "
-            "They are not officially supported by the gbasf2 developers and those are not guaranteed to work"
+            f"The characters \"-\" or \"_\" are used in the project name \"{gbasf2_project_name}\". "
+            "They are not officially supported by the gbasf2 developers and those are not guaranteed to work."
         )
     return gbasf2_project_name

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -87,7 +87,7 @@ class Gbasf2Process(BatchProcess):
                         │   └── ...
                         ├── D_ntuple.root
                         │   └── D_ntuple_0.root
-                        │   └── ... 
+                        │   └── ...
 
 
 
@@ -596,6 +596,7 @@ class Gbasf2GridProjectTarget(Target):
     Target exists if an output dataset for the project exists on the grid and is
     not being written to, i.e. all jobs that produced the dataset are done.
     """
+
     def __init__(self, project_name, dirac_user=None):
         """
         :param project_name: Name of the gbasf2 grid project that produced the
@@ -666,7 +667,7 @@ def get_gbasf2_project_job_status_dict(gbasf2_project_name, dirac_user=None):
         dirac_user = get_dirac_user()
     if not check_project_exists(gbasf2_project_name, dirac_user):
         raise RuntimeError(
-            f"Failed to acces job status for project \"{gbasf2_project_name}\" doest not exist on the grid."
+            f"Failed to access status for project \"{gbasf2_project_name}\", because it does not exist on the grid."
         )
     job_status_script_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                           "gbasf2_utils/gbasf2_job_status.py")


### PR DESCRIPTION
Adresses: https://github.com/nils-braun/b2luigi/issues/44

Allows `-` and `_` and gbasf2 project names, but issues a warning if any non-alphanumerics are used. These characters currently seem to work but are not officially supported by the gbasf2 devs according to this confluence quote:

> - The length of a project name must be less than or equal to 32 characters that consists of alphanumerics ([a-zA-Z0-9]).
>   - Allowed characters are alphanumerics ([a-zA-Z0-9]) to avoid unexpected side effect on file system or database.
>   - '.' should be avoided because it prevents registration of output to the metadata catalog, leading to job failures even when your jobs can be completed to run. See GBasf2 Troubleshooting.
>   - '-' and '_' seem to work in standard use cases, though not guaranteed
>     against every aspect.

In the process I changed the assert by a `ValueError` and used this PR to convert other asserts to exceptions. There, I also improved some of the value checks.

- [x] test this PR: I haven't tested the new code yet except the usual static flake8 checks of my IDE, so maybe wait with merging until I have done that. But wanted to put that here so that I can link to this PR in the issue.