### PR TITLE
Modified `setup_dirac_proxy` time parsing to allow for proxies with time greater than 24 hours

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -779,8 +779,8 @@ def setup_dirac_proxy():
     for line in proxy_info_str.splitlines():
         if line.startswith("timeleft"):
             timeleft_str = line.split(":", 1)[1].strip()
-            timeleft = datetime.strptime(timeleft_str, '%H:%M:%S')
-            timeleft_delta = timedelta(hours=timeleft.hour, minutes=timeleft.minute, seconds=timeleft.second)
+            hours, minutes, seconds = map(int, timeleft_str.split(":"))
+            timeleft_delta = timedelta(hours=hours, minutes=minutes, seconds=seconds)
             if timeleft_delta.total_seconds() > 0:
                 return proxy_info_str
     # initiallize proxy


### PR DESCRIPTION
I initialised a proxy for 72 hours, but the time parsing failed, since `setup_dirac_proxy` tried to match a string like `'71:42:32'` to `'%H:%M:%S'`.

As far as I know, there is no `strptime` alternative to `%H` to accept numbers greater than 23. In this PR, I split the time string and pass each component to `timedelta`, which resolves the issue.