### PR TITLE
Feature/update luigi release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -1,5 +1,5 @@
 """Task scheduling and batch running for basf2 jobs made simple"""
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from luigi import *
 from luigi.util import inherits, copies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Nils Braun'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.5.0'
+release = '0.5.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,4 @@ author-email = "nils.braun@kit.edu"
 home-page = "https://github.com/nils-braun/b2luigi"
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 
-requires=['luigi<2.7.9', 'parse>=1.8.4', 'GitPython>=2.1.11', "colorama>=0.3.9", "cachetools>=2.1.0", "jinja2"]
+requires=['luigi>=3.0.2', 'parse>=1.8.4', 'GitPython>=2.1.11', "colorama>=0.3.9", "cachetools>=2.1.0", "jinja2"]


### PR DESCRIPTION
I don't exactly remember the history of using `luigi<2.7.9`, but I think we can now upgrade to  `luigi>=3.0.2'. The major release 3 dropped python2 support, which simplifies the dependencies.

E.g. instead of tornado version  `'tornado>=4.0,<5',` which [conflicts](https://github.com/jupyter/notebook/blob/02024f0b9a9abd8f732379d915d451fd3a2f5c1c/setup.py#L101) with jupyter notebooks, it [requires](https://github.com/spotify/luigi/blob/edd868bdd10353a55517cc866e614092abb62af6/setup.py#L51)  `'tornado>=5.0,<7'`. I was a bit worried that just ignoring the warning messages during install might not be enough when the [new pip depency resolver](https://blog.python.org/2020/07/upgrade-pip-20-2-changes-20-3.html) arrives.

 3.0.2 dropped python 3.3 and 3.4 support, but I don't remember any basf2 releases of my time at Belle II having a python version this ancient. 

As I saw from the [release notes](https://github.com/spotify/luigi/releases/tag/3.0.0), the python2 drop is the only backwards-compatibility breaking change and the new features mostly target the central scheduler, which is a bit prettier now and allows for progressbars. I did some jobs on this branch with the central scheduler to see if everything works and it seemed fine. @sognetic had tested this for quite a while and says it worked.