### PR TITLE
Feature/remove useless super delegation

### DIFF
--- a/b2luigi/batch/processes/htcondor.py
+++ b/b2luigi/batch/processes/htcondor.py
@@ -13,9 +13,6 @@ from b2luigi.core.executable import create_executable_wrapper
 
 class HTCondorJobStatusCache(BatchJobStatusCache):
 
-    def __init__(self):
-        super(HTCondorJobStatusCache, self).__init__()
-
     def _ask_for_job_status(self, job_id: int = None):
         """
         With HTCondor, you can check the progress of your jobs using the `condor_q` command.

--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -10,8 +10,6 @@ from b2luigi.core.executable import create_executable_wrapper
 
 
 class LSFJobStatusCache(BatchJobStatusCache):
-    def __init__(self):
-        super(LSFJobStatusCache, self).__init__()
 
     def _ask_for_job_status(self, job_id=None):
         if job_id:

--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -30,7 +30,7 @@ class LSFProcess(BatchProcess):
     """
     Reference implementation of the batch process for a LSF batch system.
 
-    Additional to the basic batch setup (see :ref:`batch-label`), additional 
+    Additional to the basic batch setup (see :ref:`batch-label`), additional
     LSF-specific things are:
 
     * the LSF queue can be controlled via the ``queue`` parameter, e.g.
@@ -47,7 +47,6 @@ class LSFProcess(BatchProcess):
       This also applies we start in the same working directory and can reuse
       the same executable etc.
       Normally, you do not need to supply ``env_script`` or alike.
-       
     """
 
     def __init__(self, *args, **kwargs):
@@ -104,4 +103,4 @@ class LSFProcess(BatchProcess):
         if not self._batch_job_id:
             return
 
-        subprocess.run(["bkill", self._batch_job_id], stdout=subprocess.DEVNULL)
+        subprocess.run(["bkill", self._batch_job_id], stdout=subprocess.DEVNULL, check=False)


### PR DESCRIPTION
I noticed some pylint warnings when working on features in another branch. The main thing is that the 

```python
super(<class name>, self).__init__()
```

is  not needed when no non-default arguments are passed to the constructor. The only reason why this might be useful is that new developers that aim to create their own batch-backend might start by adapting the LSF cache implementation (I did at least) and it might be good to have a reminder that they can implement a custom cache size and ttl. But even in this case, I would use the simpler python3-form super form without arguments of 

```python3
super().__init__()
```

The other change are just trailing whitespace and an explicit `check=False` in the run method, which is the default, but the zen of python (and pylint again) tell us to be specific about silencing errors. Not sure if I really agree with pylint here, but `run` is kind of new in the subprocess library and I at least always forget which is the default.