### PR TITLE
Refactor away else/elif-return

### DIFF
--- a/b2luigi/basf2_helper/data.py
+++ b/b2luigi/basf2_helper/data.py
@@ -73,17 +73,17 @@ def _get_dir_structure(data_mode):
                                    "/hsm/belle2/bdata/Data/release-{p.release}/DB{p.database:08d}/prod{p.prod:08d}/" + \
                                    "e{p.experiment_number:04d}/4S/r{p.run_number:05d}/all/mdst/sub00/" + \
                                    "mdst.{p.prefix}.{p.experiment_number:04d}.{p.run_number:05d}.{p.file_name}.root")
-    elif data_mode == DataMode.cdst:
+    if data_mode == DataMode.cdst:
         return b2luigi.get_setting("cdst_dir_structure",
                                    "/hsm/belle2/bdata/Data/release-{p.release}/DB{p.database:08d}/prod{p.prod:08d}/" + \
                                    "e{p.experiment_number:04d}/4S/r{p.run_number:05d}/all/cdst/sub00/" + \
                                    "cdst.{p.prefix}.{p.experiment_number:04d}.{p.run_number:05d}.{p.file_name}.root")
-    elif data_mode == DataMode.skimmed_raw:
+    if data_mode == DataMode.skimmed_raw:
         return b2luigi.get_setting("skimmed_raw_dir_structure",
                                    "/hsm/belle2/bdata/Data/release-{p.release}/DB{p.database:08d}/prod{p.prod:08d}/" + \
                                    "e{p.experiment_number:04d}/4S/r{p.run_number:05d}/all/raw/sub00/" + \
                                    "raw.{p.prefix}.{p.file_name}.{p.experiment_number:04d}.{p.run_number:05d}.root")
-    elif data_mode == DataMode.raw:
+    if data_mode == DataMode.raw:
         return b2luigi.get_setting("raw_dir_structure",
                                    "/ghi/fs01/belle2/bdata/Data/Raw/e{p.experiment_number:04d}/r{p.run_number:05d}/sub00/" + \
                                    "{p.prefix}.{p.experiment_number:04d}.{p.run_number:05d}.{p.file_name}.root")

--- a/b2luigi/basf2_helper/tasks.py
+++ b/b2luigi/basf2_helper/tasks.py
@@ -18,8 +18,7 @@ class Basf2Task(b2luigi.DispatchableTask):
         file_name = self.get_output_file_name(*args, **kwargs)
         if os.path.splitext(file_name)[-1] == ".root":
             return ROOTLocalTarget(file_name)
-        else:
-            return super().get_output_file_target(*args, **kwargs)
+        return super().get_output_file_target(*args, **kwargs)
 
     def get_serialized_parameters(self):
         serialized_parameters = get_serialized_parameters(self)

--- a/b2luigi/basf2_helper/utils.py
+++ b/b2luigi/basf2_helper/utils.py
@@ -11,7 +11,6 @@ def get_basf2_git_hash():
 
         if basf2_release_location:
             return git.Repo(basf2_release_location).head.object.hexsha
-        else:
-            return "not_set"
+        return "not_set"
 
     return basf2_release

--- a/b2luigi/batch/processes/__init__.py
+++ b/b2luigi/batch/processes/__init__.py
@@ -142,13 +142,13 @@ class BatchProcess:
             self._put_to_result_queue(status=luigi.scheduler.DONE, explanation=job_output)
             self._terminated = True
             return False
-        elif job_status == JobStatus.aborted:
+        if job_status == JobStatus.aborted:
             job_output = ""
             self._put_to_result_queue(status=luigi.scheduler.FAILED, explanation=job_output)
             on_failure(self.task, job_output)
             self._terminated = True
             return False
-        elif job_status == JobStatus.running:
+        if job_status == JobStatus.running:
             return True
 
         raise ValueError("get_job_status() returned an unknown job state!")

--- a/b2luigi/batch/processes/htcondor.py
+++ b/b2luigi/batch/processes/htcondor.py
@@ -147,12 +147,11 @@ class HTCondorProcess(BatchProcess):
 
         if job_status in [HTCondorJobStatus.completed]:
             return JobStatus.successful
-        elif job_status in [HTCondorJobStatus.idle, HTCondorJobStatus.running]:
+        if job_status in [HTCondorJobStatus.idle, HTCondorJobStatus.running]:
             return JobStatus.running
-        elif job_status in [HTCondorJobStatus.removed, HTCondorJobStatus.held, HTCondorJobStatus.failed]:
+        if job_status in [HTCondorJobStatus.removed, HTCondorJobStatus.held, HTCondorJobStatus.failed]:
             return JobStatus.aborted
-        else:
-            raise ValueError(f"Unknown HTCondor Job status: {job_status}")
+        raise ValueError(f"Unknown HTCondor Job status: {job_status}")
 
     def start_job(self):
         submit_file = self._create_htcondor_submit_file()

--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -65,7 +65,7 @@ class LSFProcess(BatchProcess):
 
         if job_status == "DONE":
             return JobStatus.successful
-        elif job_status == "EXIT":
+        if job_status == "EXIT":
             return JobStatus.aborted
 
         return JobStatus.running

--- a/b2luigi/batch/processes/test.py
+++ b/b2luigi/batch/processes/test.py
@@ -20,10 +20,9 @@ class TestProcess(BatchProcess):
 
         if returncode is None:
             return JobStatus.running
-        elif returncode:
+        if returncode:
             return JobStatus.aborted
-        else:
-            return JobStatus.successful
+        return JobStatus.successful
 
     def start_job(self):
         log_file_dir = get_log_file_dir(self.task)

--- a/b2luigi/cli/runner.py
+++ b/b2luigi/cli/runner.py
@@ -109,6 +109,5 @@ def dry_run(task_list):
     if non_completed_tasks:
         print("In total", non_completed_tasks)
         exit(1)
-    else:
-        print("All tasks are finished!")
-        exit(0)
+    print("All tasks are finished!")
+    exit(0)

--- a/b2luigi/core/task.py
+++ b/b2luigi/core/task.py
@@ -74,8 +74,7 @@ class Task(luigi.Task):
 
         if key is not None:
             return file_paths[key]
-        else:
-            return file_paths
+        return file_paths
 
 
     def get_input_file_names(self, key=None):

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -97,10 +97,9 @@ def flatten_to_file_paths(inputs):
     if isinstance(inputs, dict):
         return {os.path.basename(flatten_to_file_paths(key)):
                 flatten_to_file_paths(value) for key, value in inputs.items()}
-    elif isinstance(inputs, list):
+    if isinstance(inputs, list):
         return [flatten_to_file_paths(value) for value in inputs]
-    else:
-        return inputs
+    return inputs
 
 
 def flatten_to_dict(inputs):


### PR DESCRIPTION
Refactored some `elif...return...`  case constucts, as after a return statement or exception there is no need else/elif. I noticed this via pylint, see [R1705](https://pheanex.github.io/pylint/#R1705). Had started refactoring this wile working on another feature branch and decided to put it into a separate PR. If you think the previous version is more readable, feel free to comment, since  according to the Zen of Python *Readability counts.* and this is the only thing that should be affected by this.


