### PR TITLE
Update team list with Michael as main developer

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -126,12 +126,12 @@ Original author:
 
 Features, fixing, help and testing:
 
-* Felix Metzner
-* Patrick Ecker
+* Felix Metzner (`FelixMetzner`_)
+* Patrick Ecker (`eckerpatrick`_)
 * Jochen Gemmler
-* Maximilian Welsch
-* Kilian Lieret
-* Sviatoslav Bilokin
+* Maximilian Welsch (`welschma`_)
+* Kilian Lieret (`klieret`_)
+* Sviatoslav Bilokin (`bilokin`_)
 * Phil Grace
 
 Stolen ideas:
@@ -141,10 +141,15 @@ Stolen ideas:
 
 
 .. _github: https://github.com/nils-braun/b2luigi
-.. _`luigi documentation`: http://luigi.readthedocs.io/en/stable/
-.. _`Belle II`: http://belle2.org/
-.. _`nils-braun`: http://github.com/nils-braun
-.. _`meliache`: http://github.com/meliache
+.. _`luigi documentation`: https://luigi.readthedocs.io/en/stable
+.. _`Belle II`: https://www.belle2.org
+.. _`nils-braun`: https://github.com/nils-braun
+.. _`meliache`: https://github.com/meliache
+.. _`welschma`: https://github.com/welschma
+.. _`FelixMetzner`: https://github.com/FelixMetzner
+.. _`eckerpatrick`: https://github.com/eckerpatrick
+.. _`klieret`: https://github.com/klieret
+.. _`bilokin`: https://github.com/bilokin
 .. _`sge`: https://github.com/spotify/luigi/blob/master/luigi/contrib/sge.py
 .. _`lsf`: https://github.com/spotify/luigi/pull/2373/files
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,7 +129,7 @@ Features, fixing, help and testing
     * Maximilian Welsch (`welschma`_)
     * Kilian Lieret (`klieret`_)
     * Sviatoslav Bilokin (`bilokin`_)
-    * Phil Grace
+    * Phil Grace (`philiptgrace`_)
 
 Stolen ideas
     * Implementation of SGE batch system (`sge`_).
@@ -146,6 +146,7 @@ Stolen ideas
 .. _`eckerpatrick`: https://github.com/eckerpatrick
 .. _`klieret`: https://github.com/klieret
 .. _`bilokin`: https://github.com/bilokin
+.. _`philiptgrace`: https://github.com/philiptgrace
 .. _`sge`: https://github.com/spotify/luigi/blob/master/luigi/contrib/sge.py
 .. _`lsf`: https://github.com/spotify/luigi/pull/2373/files
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,6 +118,10 @@ The team
 
 Main developer:
 
+* Michael Eliachevitch (`meliache`_)
+
+Original author:
+
 *   Nils Braun (`nils-braun`_)
 
 Features, fixing, help and testing:
@@ -125,7 +129,6 @@ Features, fixing, help and testing:
 *   Felix Metzner
 *   Patrick Ecker
 *   Jochen Gemmler
-*   Michael Eliachevitch
 *   Maximilian Welsch
 
 Stolen ideas:
@@ -138,6 +141,7 @@ Stolen ideas:
 .. _`luigi documentation`: http://luigi.readthedocs.io/en/stable/
 .. _`Belle II`: http://belle2.org/
 .. _`nils-braun`: http://github.com/nils-braun
+.. _`meliache`: http://github.com/meliache
 .. _`sge`: https://github.com/spotify/luigi/blob/master/luigi/contrib/sge.py
 .. _`lsf`: https://github.com/spotify/luigi/pull/2373/files
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,28 +116,24 @@ The name
 The team
 --------
 
-Main developer:
+Main developer
+    Michael Eliachevitch (`meliache`_)
 
-* Michael Eliachevitch (`meliache`_)
+Original author
+    Nils Braun (`nils-braun`_)
 
-Original author:
+Features, fixing, help and testing
+    * Felix Metzner (`FelixMetzner`_)
+    * Patrick Ecker (`eckerpatrick`_)
+    * Jochen Gemmler
+    * Maximilian Welsch (`welschma`_)
+    * Kilian Lieret (`klieret`_)
+    * Sviatoslav Bilokin (`bilokin`_)
+    * Phil Grace
 
-* Nils Braun (`nils-braun`_)
-
-Features, fixing, help and testing:
-
-* Felix Metzner (`FelixMetzner`_)
-* Patrick Ecker (`eckerpatrick`_)
-* Jochen Gemmler
-* Maximilian Welsch (`welschma`_)
-* Kilian Lieret (`klieret`_)
-* Sviatoslav Bilokin (`bilokin`_)
-* Phil Grace
-
-Stolen ideas:
-
-*   Implementation of SGE batch system (`sge`_).
-*   Implementation of LSF batch system (`lsf`_).
+Stolen ideas
+    * Implementation of SGE batch system (`sge`_).
+    * Implementation of LSF batch system (`lsf`_).
 
 
 .. _github: https://github.com/nils-braun/b2luigi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,14 +122,17 @@ Main developer:
 
 Original author:
 
-*   Nils Braun (`nils-braun`_)
+* Nils Braun (`nils-braun`_)
 
 Features, fixing, help and testing:
 
-*   Felix Metzner
-*   Patrick Ecker
-*   Jochen Gemmler
-*   Maximilian Welsch
+* Felix Metzner
+* Patrick Ecker
+* Jochen Gemmler
+* Maximilian Welsch
+* Kilian Lieret
+* Sviatoslav Bilokin
+* Phil Grace
 
 Stolen ideas:
 


### PR DESCRIPTION
The main change introduced by this commit is that following the proposal in #53 I added myself as the main developer, but added for @nils-braun the special position of _Original author_.

I checked the contributors from the git logs and added @klieret , @bilokin and @philiptgrace, who all helped out, but were not in the list yet. Further I added the links to the github user pages for all contributors for whom I could find them, i.e. in addition to the ones I already mentioned also @eckerpatrick, @welschma, @FelixMetzner.

I @-mention you people so that you can object in the comments if you have any privacy concerns or similar about your real name and github profile being linked here. 

The last change introduced in this commit is that I slightly improved the formatting by using an RST definition list, so now it looks like this:
![grafik](https://user-images.githubusercontent.com/5121824/107295668-2257e880-6a70-11eb-81cc-767a1bc8a567.png)


If wanted, I could also put in some work to add the github user thumbnails next to the author names, as e.g. @klieret  had done [here](https://github.com/hsf-training/hsf-training-ssh-webpage/blob/gh-pages/README.md#authors).

But I shouldn't distract too much from the main change, me as the main developer, so comment e.g. if you want the position to be called differently. After all, 80% of the commits are still from Nils.