### PR TITLE
Fix validation of downloaded grid dataset for duplicate LFNs

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -592,10 +592,12 @@ class Gbasf2Process(BatchProcess):
                 raise RuntimeError(f"No output data for gbasf2 project {self.gbasf2_project_name} found.")
             tmp_output_dir = os.path.join(tmp_output_dir_path, self.gbasf2_project_name, 'sub00')
             if not self._local_gb2_dataset_is_complete(output_file_name, check_temp_dir=True, verbose=True):
-                raise RuntimeError(
-                    f"The downloaded set of files in {tmp_output_dir} is not equal to the " +
+                warnings.warn(
+                    f"Download incomplete. The downloaded set of files in {tmp_output_dir} is not equal to the " +
                     f"list of dataset files on the grid for project {self.gbasf2_project_name}."
                 )
+                return
+
             print(f"Download of {self.gbasf2_project_name} files successful.\n"
                   f"Moving output files to directory: {output_dir_path}")
             if os.path.exists(output_dir_path):

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -592,12 +592,10 @@ class Gbasf2Process(BatchProcess):
                 raise RuntimeError(f"No output data for gbasf2 project {self.gbasf2_project_name} found.")
             tmp_output_dir = os.path.join(tmp_output_dir_path, self.gbasf2_project_name, 'sub00')
             if not self._local_gb2_dataset_is_complete(output_file_name, check_temp_dir=True, verbose=True):
-                warnings.warn(
-                    f"Download incomplete. The downloaded set of files in {tmp_output_dir} is not equal to the " +
+                raise RuntimeError(
+                    f"The downloaded set of files in {tmp_output_dir} is not equal to the " +
                     f"list of dataset files on the grid for project {self.gbasf2_project_name}."
                 )
-                return
-
             print(f"Download of {self.gbasf2_project_name} files successful.\n"
                   f"Moving output files to directory: {output_dir_path}")
             if os.path.exists(output_dir_path):

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -12,7 +12,7 @@ from collections import Counter
 from datetime import datetime
 from functools import lru_cache
 from itertools import groupby
-from typing import Iterable, List
+from typing import Iterable, Set
 
 from b2luigi.basf2_helper.utils import get_basf2_git_hash
 from b2luigi.batch.processes import BatchProcess, JobStatus
@@ -897,7 +897,7 @@ def _get_lfn_upto_reschedule_number(lfn: str) -> str:
     return "_".join(lfn.split("_")[:-1])
 
 
-def get_unique_lfns(lfns: Iterable[str]) -> List[str]:
+def get_unique_lfns(lfns: Iterable[str]) -> Set[str]:
     """
     From list of gbasf2 LFNs which include duplicate outputs for rescheduled
     jobs return filtered list which only include the LFNs for the jobs with the
@@ -915,4 +915,4 @@ def get_unique_lfns(lfns: Iterable[str]) -> List[str]:
     # if it is of the gbasf v5 form, group the outputs by the substring upto the
     # reschedule number and return list of maximums of each group
     lfns = sorted(lfns, key=_get_lfn_upto_reschedule_number)
-    return [max(lfn_group) for _, lfn_group in groupby(lfns, key=_get_lfn_upto_reschedule_number)]
+    return {max(lfn_group) for _, lfn_group in groupby(lfns, key=_get_lfn_upto_reschedule_number)}

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -894,6 +894,11 @@ def _get_lfn_upto_reschedule_number(lfn: str) -> str:
     E.g. if the LFN is ``<name>_<gbasf2param>_<jobID>_<rescheduleNum>.root``
     return ````<name>_<gbasf2param>_<jobID>``.
     """
+    if not lfn_follows_gb2v5_convention(lfn):
+        raise ValueError(
+            "LFN does does not conform to the new gbasf2 v5 style, "
+            "thus getting the substring upto the reschedule number does not make sense"
+        )
     return "_".join(lfn.split("_")[:-1])
 
 

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -896,7 +896,7 @@ def _get_lfn_upto_reschedule_number(lfn: str) -> str:
     E.g. if the LFN is ``<name>_<gbasf2param>_<jobID>_<rescheduleNum>.root``
     return ````<name>_<gbasf2param>_<jobID>``.
     """
-    return "_".join(lfn.split("_")[0:4])
+    return "_".join(lfn.split("_")[:-1])
 
 
 def get_unique_lfns(lfns: Iterable[str]) -> List[str]:

--- a/tests/batch/test_gbasf2_helper_functions.py
+++ b/tests/batch/test_gbasf2_helper_functions.py
@@ -1,0 +1,118 @@
+"""
+Test helper functions for :py:class:`Gbasf2Process`.
+
+Utilities that require a running gbasf2 or Dirac environment will not net
+tested in this test case, only the functions that can be run independently.
+"""
+
+import unittest
+
+from b2luigi.batch.processes.gbasf2 import (_get_lfn_upto_reschedule_number, get_unique_lfns,
+                                            lfn_follows_gb2v5_convention)
+
+# first test utilities for working with logical file names on the grid
+
+class TestLFNFollowsGbasf2V5Convention(unittest.TestCase):
+    def test_newstyle_lfn_is_true(self):
+        lfn = 'Upsilon4SBpcandee_00000_job181817516_03.root'
+        self.assertTrue(lfn_follows_gb2v5_convention(lfn))
+
+    def test_oldstyle_lfn_is_false(self):
+        lfn = 'my_ntuple_0001.root'
+        self.assertFalse(lfn_follows_gb2v5_convention(lfn))
+
+
+class TestLFNUptoRescheduleNumber(unittest.TestCase):
+    def test_strings_equal_camelcase_lfn(self):
+        lfn = 'Upsilon4SBpcandee_00000_job181817516_03.root'
+        self.assertEqual(_get_lfn_upto_reschedule_number(lfn), 'Upsilon4SBpcandee_00000_job181817516')
+
+    def test_strings_equal_snakecase_lfn(self):
+        lfn = 'my_ntuple_name_00000_job181817516_03.root'
+        self.assertEqual(_get_lfn_upto_reschedule_number(lfn), 'my_ntuple_name_00000_job181817516')
+
+    def test_oldstyle_lfn_raises_error(self):
+        lfn = 'my_ntuple_0001.root'
+        with self.assertRaises(ValueError):
+            _get_lfn_upto_reschedule_number(lfn)
+
+
+class TestGetUniqueLFNS(unittest.TestCase):
+    def setUp(self):
+        # list of logical path names on the grid that only differe by the reschedule number (last two digits)
+        self.lfns_with_duplicates = [
+            'Upsilon4SBpcandee_00000_job181817516_00.root',
+            'Upsilon4SBpcandee_00001_job181817517_00.root',
+            'Upsilon4SBpcandee_00002_job181817518_00.root',
+            'Upsilon4SBpcandee_00003_job181817519_00.root',
+            'Upsilon4SBpcandee_00004_job181817520_00.root',
+            'Upsilon4SBpcandee_00005_job181817521_00.root',
+            'Upsilon4SBpcandee_00006_job181817522_00.root',
+            'Upsilon4SBpcandee_00007_job181817523_00.root',
+            'Upsilon4SBpcandee_00008_job181817524_00.root',
+            'Upsilon4SBpcandee_00009_job181817525_00.root',
+            'Upsilon4SBpcandee_00010_job181817526_00.root',
+            'Upsilon4SBpcandee_00011_job181817527_00.root',
+            'Upsilon4SBpcandee_00012_job181817528_00.root',
+            'Upsilon4SBpcandee_00012_job181817528_00.root',
+            'Upsilon4SBpcandee_00012_job181817528_02.root',
+            'Upsilon4SBpcandee_00013_job181817529_00.root',
+            'Upsilon4SBpcandee_00014_job181817530_00.root',
+            'Upsilon4SBpcandee_00015_job181817531_00.root',
+            'Upsilon4SBpcandee_00016_job181817532_00.root',
+            'Upsilon4SBpcandee_00017_job181817533_00.root',
+            'Upsilon4SBpcandee_00017_job181817533_01.root',
+            'Upsilon4SBpcandee_00017_job181817533_02.root',
+            'Upsilon4SBpcandee_00018_job181817534_01.root',
+            'Upsilon4SBpcandee_00019_job181817535_00.root',
+        ]
+        # create same input but with more underscores in initial root file name (snake case)
+        # to test whether the string splitting logic is stable in that case
+        self.lfns_with_duplicates_snake_case = [
+            lfn.replace("Upsilon4SBpcandee", "u4s_Bp_cand_") for lfn in self.lfns_with_duplicates
+        ]
+        self.unique_lfns = {
+            'Upsilon4SBpcandee_00000_job181817516_00.root',
+            'Upsilon4SBpcandee_00001_job181817517_00.root',
+            'Upsilon4SBpcandee_00002_job181817518_00.root',
+            'Upsilon4SBpcandee_00003_job181817519_00.root',
+            'Upsilon4SBpcandee_00004_job181817520_00.root',
+            'Upsilon4SBpcandee_00005_job181817521_00.root',
+            'Upsilon4SBpcandee_00006_job181817522_00.root',
+            'Upsilon4SBpcandee_00007_job181817523_00.root',
+            'Upsilon4SBpcandee_00008_job181817524_00.root',
+            'Upsilon4SBpcandee_00009_job181817525_00.root',
+            'Upsilon4SBpcandee_00010_job181817526_00.root',
+            'Upsilon4SBpcandee_00011_job181817527_00.root',
+            'Upsilon4SBpcandee_00012_job181817528_02.root',
+            'Upsilon4SBpcandee_00013_job181817529_00.root',
+            'Upsilon4SBpcandee_00014_job181817530_00.root',
+            'Upsilon4SBpcandee_00015_job181817531_00.root',
+            'Upsilon4SBpcandee_00016_job181817532_00.root',
+            'Upsilon4SBpcandee_00017_job181817533_02.root',
+            'Upsilon4SBpcandee_00018_job181817534_01.root',
+            'Upsilon4SBpcandee_00019_job181817535_00.root',
+        }
+        self.unique_lfns_snake_case = {
+            lfn.replace("Upsilon4SBpcandee", "u4s_Bp_cand_") for lfn in self.unique_lfns
+        }
+
+    def test_sets_equal(self):
+        unique_lfns = get_unique_lfns(self.lfns_with_duplicates)
+        self.assertSetEqual(unique_lfns, self.unique_lfns)
+
+    def test_count_equal(self):
+        unique_lfns = get_unique_lfns(self.lfns_with_duplicates)
+        self.assertCountEqual(unique_lfns, self.unique_lfns)
+
+    def test_sets_equal_underscore_in_file_name(self):
+        unique_lfns_snake_case = get_unique_lfns(self.lfns_with_duplicates_snake_case)
+        self.assertSetEqual(unique_lfns_snake_case, self.unique_lfns_snake_case)
+
+    def test_sets_equal_input_as_set(self):
+        unique_lfns = get_unique_lfns(set(self.lfns_with_duplicates))
+        self.assertSetEqual(unique_lfns, self.unique_lfns)
+
+    def test_sets_equal_underscore_in_file_name_input_as_set(self):
+        unique_lfns_snake_case = get_unique_lfns(set(self.lfns_with_duplicates_snake_case))
+        self.assertSetEqual(unique_lfns_snake_case, self.unique_lfns_snake_case)


### PR DESCRIPTION
For checking if a grid dataset has been completely downloaded, I compare the output of `gb2_ds_list` (lists the remote dataset) with the list of downloaded files. However, since gbasf2 release 5, `gb2_ds_list` also lists duplicate outputs from jobs that had been rescheduled. The `gb2_ds_get` download script filters those out, but with this, I can't simply use the comparison anymore.

Thus, via this PR I manually filter out the duplicated remote LFN's and only show those with the highest number. For the logic, I adapted some of the code of gbasf2/BelleDirac, in particular the [`findDuplicatedJobID()`](https://stash.desy.de/projects/B2DC/repos/belledirac/browse/gbasf2/lib/ds/util.py#214) function:


Sadly, it also just uses string parsing. I was a little worried that it might brake for old datasets produced with old gbasf2 versions, but I try to recognize if the job LFN is the new version and if it's not I don't remove anything.

There is a gbasf2 issue to do this filtering automatically, see [BIIDCD-1240](https://agira.desy.de/browse/BIIDCD-1240), so after that's merged this code might be simplified.

My wish is that it will be possible to just rely on the exit code of `gb2_ds_get` to know if a dataset has been successfully and completely downloaded. This whish has been also formulated into an issue, see [BIIDCD-1238](https://agira.desy.de/browse/).

As far as I know @bilokin  already had a workaround by disabling the comparison of datasets altogether. Maybe he or some other people could test this. Before doing this fix, I had merged the PR #67 which refactored the download function and made the partial download directories persistent, which made debugging of the download and the implementation of changes much simpler. However, for that PR I hadn't waited for reviews of other people. Maybe it would be good if others could check if their b2luigi works for the head of this branch. Remember, you can just install it for testing, e.g. with

```
python3 -m pip install --upgrade --user "git+https://github.com/nils-braun/b2luigi@bugfix/workaround-duplicate-files-in-gbasf2v5"
```