### PR TITLE
call dry_run method of non finished tasks during dry-run

### DIFF
--- a/b2luigi/cli/runner.py
+++ b/b2luigi/cli/runner.py
@@ -105,7 +105,7 @@ def dry_run(task_list):
 
             # execute the dry_run method of the task if it is implemented
             if hasattr(task, 'dry_run'):
-                print("\t----------- call: dry_run() -------------")
+                print("\tcall: dry_run()")
                 task.dry_run()
             print()
 

--- a/b2luigi/cli/runner.py
+++ b/b2luigi/cli/runner.py
@@ -102,6 +102,11 @@ def dry_run(task_list):
         print(task_class)
         for task in nonfinished_task_list[task_class]:
             print("\tWould run", task)
+
+            # execute the dry_run method of the task if it is implemented
+            if hasattr(task, 'dry_run'):
+                print("\t----------- call: dry_run() -------------")
+                task.dry_run()
             print()
 
             non_completed_tasks += 1

--- a/docs/documentation/run_modes.rst
+++ b/docs/documentation/run_modes.rst
@@ -24,7 +24,20 @@ where mode can be one of:
     (see :ref:`batch-label`) to one of the supported systems.
 
 *   **dry-run**: Similar to the dry-run funtionality of ``luigi``, this will not start any tasks but just tell
-    you, which tasks it would run. The exit code is 1 in case a task needs to run and 0 otherwise.
+    you, which tasks it would run, and call the ``dry_run`` method of the task if implemented:
+
+    .. code-block:: python
+
+        class SomeTask(b2luigi.Task):
+            [...]
+            def dry_run(self):
+                # if a method with this name is provided, it will be executed
+                # automatically when starting the processing in dry-run mode
+                do_some_stuff_in_dry_run_mode()
+
+    This feature can be easily used for e.g. file name debugging, i.e. to print out the file names ``b2luigi`` 
+    will create when running the actual task. The exit code of the ``dry-run`` mode is 1 in case a task needs 
+    to run and 0 otherwise.
 
 *   **show-output**: List all output files that this has produced/will produce. Files which already exist
     (where the targets define, what exists mean in this case) are marked as green whereas missing targets are


### PR DESCRIPTION
I've implemented a small feature when the `dry-run` run mode was chosen, which then calls the `dry_run()` method of not finished tasks. This allows an easy and fast way to implement e.g. file output debugging. One just put some print statement with path information in a `dry_run` method and execute in `dry-run` mode and has the results one is looking for. 

Example: 

adding method to a child of a `Task` object

```
class SomeTask(b2luigi.Task):
[...]
    def dry_run(self):
        # get list of path objects from any other method
        paths = self.get_output_paths()
        for p in paths:
            print(str(p))
```

output of `dry-run` mode without a dry_run class:
```
SomeTask
        Would run SomeTask[...]
```

output of `dry-run` mode with a dry_run method:
```
SomeTask
        Would run SomeTask[...]
        ----------- call: dry_run() -------------
/path/to/output.file
/path/to/another_output.file
```

There is a point about backward compatibility, I am not sure how to handle it. What happens with old code having a `dry_run` method implemented and which should not be executed in `dry-run` mode. So we should provide some mechanism to suppress the call. But I'm not sure where to place this. Any suggestions?