### PR TITLE
Don't raise exception when download failed

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -289,7 +289,7 @@ class Gbasf2Process(BatchProcess):
                 try:
                     self._on_first_success_action()
                     self._project_had_been_successful = True
-                # RuntimeError might occur when download out output dataset was not complete. This is
+                # RuntimeError might occur when download of output dataset was not complete. This is
                 # frequent, so we want to catch that error and just marking the job as failed
                 except RuntimeError as err:
                     warnings.warn(err, RuntimeError)

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -359,7 +359,7 @@ class Gbasf2Process(BatchProcess):
         Submit new gbasf2 project to grid
         """
         if check_project_exists(self.gbasf2_project_name, self.dirac_user):
-            warnings.warn(
+            print(
                 f"\nProject with name {self.gbasf2_project_name} already exists on grid, "
                 "therefore not submitting new project. If you want to submit a new project, "
                 "change the project name."

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -592,10 +592,12 @@ class Gbasf2Process(BatchProcess):
                 raise RuntimeError(f"No output data for gbasf2 project {self.gbasf2_project_name} found.")
             tmp_output_dir = os.path.join(tmp_output_dir_path, self.gbasf2_project_name, 'sub00')
             if not self._local_gb2_dataset_is_complete(output_file_name, check_temp_dir=True, verbose=True):
-                raise RuntimeError(
-                    f"The downloaded set of files in {tmp_output_dir} is not equal to the " +
+                warnings.warn(
+                    f"Download incomplete. The downloaded set of files in {tmp_output_dir} is not equal to the " +
                     f"list of dataset files on the grid for project {self.gbasf2_project_name}."
                 )
+                return
+
             print(f"Download of {self.gbasf2_project_name} files successful.\n"
                   f"Moving output files to directory: {output_dir_path}")
             if os.path.exists(output_dir_path):

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -333,7 +333,10 @@ class Gbasf2Process(BatchProcess):
         for job_id, job_info in job_status_dict.items():
             if job_info["Status"] == "Failed":
                 if self.n_retries_by_job[job_id] >= self.max_retries:
-                    warnings.warn(f"Reached maximum number of rescheduling tries ({self.max_retries}) for job {job_id}.")
+                    warnings.warn(
+                        f"Reached maximum number of rescheduling tries ({self.max_retries}) for job {job_id}.",
+                        RuntimeWarning
+                    )
                     return False
                 self._reschedule_job(job_id)
                 self.n_retries_by_job[job_id] += 1
@@ -594,7 +597,8 @@ class Gbasf2Process(BatchProcess):
             if not self._local_gb2_dataset_is_complete(output_file_name, check_temp_dir=True, verbose=True):
                 warnings.warn(
                     f"Download incomplete. The downloaded set of files in {tmp_output_dir} is not equal to the " +
-                    f"list of dataset files on the grid for project {self.gbasf2_project_name}."
+                    f"list of dataset files on the grid for project {self.gbasf2_project_name}.",
+                    category=RuntimeWarning
                 )
                 return
 
@@ -683,8 +687,11 @@ def check_dataset_exists_on_grid(gbasf2_project_name, dirac_user=None):
         return False
     output_lines_are_paths = all(os.path.abspath(line) for line in output_dataset_str.strip().splitlines())
     if not output_lines_are_paths:
-        warnings.warn("The output of ``{' '.join(ds_list_command)}`` contains lines that are not grid paths:\n" +
-                      output_dataset_str)
+        warnings.warn(
+            "The output of ``{' '.join(ds_list_command)}`` contains lines that are not grid paths:\n" +
+            output_dataset_str,
+            category=RuntimeWarning
+        )
         return False
     return True
 

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -250,17 +250,7 @@ class Gbasf2Process(BatchProcess):
         to ``gb2_job_status``, and return an overall project status, e.g. when
         all jobs are done, return ``JobStatus.successful`` to show that the
         gbasf2 project succeeded.
-
-        The status of each individual job can be one of::
-
-            [Submitting, Submitted, Received, Checking, Staging, Waiting, Matched, Rescheduled,
-             Running, Stalled, Completing, Done, Completed, Failed, Deleted, Killed]
-
-        (Taken from  https://github.com/DIRACGrid/DIRAC/blob/rel-v7r1/WorkloadManagementSystem/Client/JobStatus.py)
-
         """
-        # If project is does not exist on grid yet, so can't query for gbasf2 project status
-
         job_status_dict = get_gbasf2_project_job_status_dict(self.gbasf2_project_name, dirac_user=self.dirac_user)
         n_jobs_by_status = Counter()
         for _, job_info in job_status_dict.items():
@@ -698,8 +688,8 @@ def check_dataset_exists_on_grid(gbasf2_project_name, dirac_user=None):
 
 def get_gbasf2_project_job_status_dict(gbasf2_project_name, dirac_user=None):
     """
-    Returns a dictionary for all jobs in the project with a structure like the following,
-    which I have taken and adapted from an example output::
+    Returns a dictionary for all jobs in the project with a structure like the
+    following, which I have taken and adapted from an example output::
 
         {
             "<JobID>": {
@@ -716,10 +706,10 @@ def get_gbasf2_project_job_status_dict(gbasf2_project_name, dirac_user=None):
         ...
         }
 
-    For that purpose, the script in ``gbasf2_job_status.py`` is called.
-    That script directly interfaces with Dirac via its API, but it only works with the
-    gbasf2 environment and python2, which is why it is called as a subprocess.
-    The job status dictionary is passed to this function via json.
+    For that purpose, the script in ``gbasf2_job_status.py`` is called.  That
+    script directly interfaces with Dirac via its API, but it only works with
+    the gbasf2 environment and python2, which is why it is called as a
+    subprocess.  The job status dictionary is passed to this function via json.
     """
     if dirac_user is None:
         dirac_user = get_dirac_user()


### PR DESCRIPTION
Instead don't produce the outputs. WIP goal is to also mark the job as failed during runtime. Addresses #69 