### PR TITLE
Improve development docs

### DIFF
--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -76,8 +76,6 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
             flit publish
 
-    At a later stage, I will try to automate this.
-
 
 Open TODOs
 ----------

--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -36,7 +36,18 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
         flit install -s
 
-4.  The documentation is hosted on read the docs and build automatically on every commit to main.
+    Now you can start hacking and your changes will be immediately available to you.
+
+4. We use the unittest_ package for testing some parts of the code. All tests reside in the
+   ``tests/`` sub-directory. To run all tests, run the command
+
+    .. code-block:: bash
+
+        python3 -m unittest
+
+   in the root of ``b2luigi`` repository. If you add some functionality, try to add some tests for it.
+
+5.  The documentation is hosted on `readthedocs`_ and build automatically on every commit to main.
     You can (and should) also build the documentation locally by installing ``sphinx``
 
     .. code-block:: bash
@@ -53,7 +64,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
     the created docs now (most likely http://127.0.0.1:8000).
     Please make sure the documentation looks fine before creating a pull request.
 
-5.  If you are a core developer and want to release a new version:
+6.  If you are a core developer and want to release a new version:
 
     a.  Make sure all changes are committed and merged on main
     b.  Use the ``bumpversion`` package to update the version in the python file ``b2luigi/__init__.py`` as well
@@ -84,4 +95,6 @@ For a list of potential features, improvements and bugfixes see the `github issu
 welcome, so feel free to pick one, e.g. with the ``good first issue`` or ``help wanted`` tags.
 
 .. _flit: https://pypi.org/project/flit/
-
+.. _github issues: https://github.com/nils-braun/b2luigi/issues
+.. _unittest: https://docs.python.org/3/library/unittest.html
+.. _readthedocs: https://readthedocs.org

--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -82,9 +82,8 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 Open TODOs
 ----------
 
-* Add support for different batch systems, e.g. htcondor and a batch system discovery
-* Integrate dirac or other grid systems as another batch system
-* Add helper messages on events (e.g. failed)
+For a list of potential features, improvements and bugfixes see the `github issues`_. Help is
+welcome, so feel free to pick one, e.g. with the ``good first issue`` or ``help wanted`` tags.
 
 .. _flit: https://pypi.org/project/flit/
 


### PR DESCRIPTION
First I noticed the list of TODOs in the docs and this will never be up-to-date, so I linked to the issues instead.

Also added section how to run tests, as a motivation to do so before you do a PR, since we don't have real CI. Also I personally first failed at running the tests, e.g. I had tried to run `python3 -m unittest` from within the `tests` subdirectory, but then the relative imports don't work.

And I removed the
> At a later stage, I will try to automate this.

since the  reader might now understand _I_ as the main author and I am not working on it. Also, this could also be made and enhancement issue.