### PR TITLE
Adding an option to set the lsf job_name parameter

### DIFF
--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -42,6 +42,14 @@ class LSFProcess(BatchProcess):
 
       The default is the short queue "s".
 
+    * the LSF job name can be contralled via the ``job_name`` parameter, e.g.
+      .. code-block:: python
+
+        class MyLongTask(b2luigi.Task):
+            job_name = "my_fun_job"
+
+      The default "{FULL_PATH}/executable_wrapper.sh".
+
     * By default, the environment variables from the scheduler are copied to
       the workers.
       This also applies we start in the same working directory and can reuse

--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -78,6 +78,11 @@ class LSFProcess(BatchProcess):
         except AttributeError:
             pass
 
+        try:
+            command += ["-J", self.task.job_name]
+        except AttributeError:
+            pass
+
         log_file_dir = get_log_file_dir(self.task)
         os.makedirs(log_file_dir, exist_ok=True)
 

--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -31,12 +31,12 @@ class LSFProcess(BatchProcess):
     Reference implementation of the batch process for a LSF batch system.
 
     Additional to the basic batch setup (see :ref:`batch-label`), there are
-    LSF-specific settings. These are:
+    LSF-specific :meth:`settings <b2luigi.set_setting>`. These are:
 
     * the LSF queue: ``queue``.
     * the LSF job name: ``job_name``.
 
-    Both can be controlled via the standard settings interface, e.g.
+    For example:
 
       .. code-block:: python
 
@@ -44,8 +44,11 @@ class LSFProcess(BatchProcess):
             queue = "l"
             job_name = "my_long_task"
 
-      The default queue is the short queue "s". If no job_name is set the task
-      will appear as "{result_dir}/parameter1=value/.../executable_wrapper.sh"
+      The default queue is the short queue ``"s"``. If no ``job_name`` is set the task
+      will appear as ::
+
+        <result_dir>/parameter1=value/.../executable_wrapper.sh"
+
       when running ``bjobs``.
 
     * By default, the environment variables from the scheduler are copied to

--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -79,8 +79,9 @@ class LSFProcess(BatchProcess):
     def start_job(self):
         command = ["bsub", "-env all"]
 
-        queue = get_setting("queue", task=self.task, default='s')
-        command += ["-q", queue]
+        queue = get_setting("queue", task=self.task, default=None)
+        if queue is not None:
+            command += ["-q", queue]
 
         job_name = get_setting("job_name", task=self.task, default=None)
         if job_name is not None:

--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -48,7 +48,7 @@ class LSFProcess(BatchProcess):
         class MyLongTask(b2luigi.Task):
             job_name = "my_fun_job"
 
-      The default "{FULL_PATH}/executable_wrapper.sh".
+      If no job_name is set the task will appear as "{FULL_PATH}/executable_wrapper.sh".
 
     * By default, the environment variables from the scheduler are copied to
       the workers.


### PR DESCRIPTION
I find it can be useful to get a quick overview of the running jobs through their job_name parameters on kekcc. With b2luigi submitted jobs this is set to "{FULL_PATH}/executable_wrapper.sh" which is not easy to parse at a glance. 

This PR adds the option to set a 'job_name' attribute for your tasks which is then submitted as the lsf job name (-J task.job_name).