### PR TITLE
Include global tags in pickled path object

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -70,7 +70,8 @@ class Gbasf2Process(BatchProcess):
           inhereting from ``Basf2PathTask`` or other tasks with a
           ``create_path()`` method that returns a basf2 path.
 
-        - It can be used **only for pickable basf2 paths**, as it stores
+        - It can be used **only for pickable basf2 paths**, with only some limited global basf2 state
+          saved (currently aliases and global tags). The batch process stores
           the path created by ``create_path`` in a python pickle file and runs that on the grid.
           Therefore, **python basf2 modules are not yet supported**.
           To see if the path produced by a steering file is pickable, you can try to dump it with
@@ -470,8 +471,8 @@ class Gbasf2Process(BatchProcess):
                 "Gbasf2 batch process can only used with tasks that generate basf2 paths with "
                 "a ``create_path()`` method, e.g. are an instance of ``Basf2PathTask``."
             ) from err
-        from b2luigi.batch.processes.gbasf2_utils.pickle_utils import write_path_and_aliases_to_file
-        write_path_and_aliases_to_file(basf2_path, self.pickle_file_path)
+        from b2luigi.batch.processes.gbasf2_utils.pickle_utils import write_path_and_state_to_file
+        write_path_and_state_to_file(basf2_path, self.pickle_file_path)
 
     def _create_wrapper_steering_file(self):
         """

--- a/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
+++ b/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
@@ -1,5 +1,6 @@
 import pickle
 
+from basf2 import conditions as b2conditions
 from basf2.pickle_path import serialize_path
 from variables import variables as vm
 
@@ -28,4 +29,5 @@ def write_path_and_aliases_to_file(basf2_path, file_path):
     with open(file_path, 'bw') as pickle_file:
         serialized = serialize_path(basf2_path)
         serialized["aliases"] = get_alias_dict_from_variable_manager()
+        serialized["globaltags"] = b2conditions.globaltags
         pickle.dump(serialized, pickle_file)

--- a/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
+++ b/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
@@ -16,7 +16,7 @@ def get_alias_dict_from_variable_manager():
 
 def write_path_and_state_to_file(basf2_path, file_path):
     """
-    Serialize basf2 path and variables from variable manage to file.
+    Serialize basf2 path and variables from variable manager to file.
 
     Variant of ``basf2.pickle_path.write_path_to_file``, only with additional
     serialization of the basf2 variable aliases and global tags.

--- a/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
+++ b/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
@@ -14,14 +14,16 @@ def get_alias_dict_from_variable_manager():
     return alias_dictionary
 
 
-def write_path_and_aliases_to_file(basf2_path, file_path):
+def write_path_and_state_to_file(basf2_path, file_path):
     """
-    Serialize basf2 path and variables from variable manage to file
+    Serialize basf2 path and variables from variable manage to file.
 
     Variant of ``basf2.pickle_path.write_path_to_file``, only with additional
-    serialization of the basf2 variable aliases.  The aliases are extracted from
-    the current state of the variable manager singleton and thus have to be
-    added in the python/basf2 process before calling this function.
+    serialization of the basf2 variable aliases and global tags.
+
+    The aliases are extracted from the current state of the variable manager singleton
+    and thus have to be added in the python/basf2 process before calling this function.
+    Likewise for the global tags.
 
     :param path: Basf2 path object to serialize
     :param file_path: File path to write the serialized pickle object to.
@@ -30,4 +32,5 @@ def write_path_and_aliases_to_file(basf2_path, file_path):
         serialized = serialize_path(basf2_path)
         serialized["aliases"] = get_alias_dict_from_variable_manager()
         serialized["globaltags"] = b2conditions.globaltags
+        # serialized["conditions"] = b2conditions
         pickle.dump(serialized, pickle_file)

--- a/b2luigi/batch/processes/templates/gbasf2_steering_file_wrapper.jinja2
+++ b/b2luigi/batch/processes/templates/gbasf2_steering_file_wrapper.jinja2
@@ -29,11 +29,24 @@ def apply_alias_dict_from_file(file_path):
         vm.addAlias(alias_name, alias_value)
 
 
+def get_global_tags_from_file(file_path):
+    """
+    Extract list of global tags from pickle file, and update the list of global tags.
+    """
+    with open(file_path, 'br') as pickle_file:
+        serialized = pickle.load(pickle_file)
+    try:
+        basf2.conditions.globaltags += serialized["globaltags"]
+    except KeyError:
+        pass
+
+
 pickle_file_path = "{{ pickle_file_path }}"
 if not os.path.isfile(pickle_file_path):
     raise FileNotFoundError(f"No pickle file found in {pickle_file_path}")
 
 apply_alias_dict_from_file(pickle_file_path)
+get_global_tags_from_file(pickle_file_path)
 path = b2pp.get_path_from_file(pickle_file_path)
 
 basf2.print_path(path)


### PR DESCRIPTION
Partially addresses #35 by saving the global tags list to the pickle file.