### PR TITLE
Make `job_name` setting set the `-batch_name` for htcondor

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.1
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -1,5 +1,5 @@
 """Task scheduling and batch running for basf2 jobs made simple"""
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 from luigi import *
 from luigi.util import inherits, copies

--- a/b2luigi/batch/processes/htcondor.py
+++ b/b2luigi/batch/processes/htcondor.py
@@ -125,6 +125,15 @@ class HTCondorProcess(BatchProcess):
       submission file. For an overview of possible settings refer to the `HTCondor documentation
       <https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html#>`_.
 
+    * Same as for the :ref:`LSF`, the ``job_name`` setting allows giving a meaningful name to a
+      group of jobs. If you want to be htcondor-specific, you can provide the ``JobBatchName`` as an
+      entry in the ``htcondor_settings`` dict, which will override the global ``job_name`` setting.
+      This is useful for checking the status of specific jobs with
+
+      .. code-block:: bash
+
+        condor_q -batch <job name>
+
     Example:
 
         .. literalinclude:: ../../examples/htcondor/htcondor_example.py
@@ -224,6 +233,10 @@ class HTCondorProcess(BatchProcess):
                 transfer_files.add(os.path.abspath(env_setup_script))
 
             general_settings.setdefault("transfer_input_files", ",".join(transfer_files))
+
+        job_name = get_setting("job_name", task=self.task, default=None)
+        if job_name is not None:
+            general_settings.setdefault("JobBatchName", job_name)
 
         for key, item in general_settings.items():
             submit_file_content.append(f"{key} = {item}")

--- a/b2luigi/batch/processes/htcondor.py
+++ b/b2luigi/batch/processes/htcondor.py
@@ -235,8 +235,8 @@ class HTCondorProcess(BatchProcess):
 
             general_settings.setdefault("transfer_input_files", ",".join(transfer_files))
 
-        job_name = get_setting("job_name", task=self.task, default=None)
-        if job_name is not None:
+        job_name = get_setting("job_name", task=self.task, default=False)
+        if job_name is not False:
             general_settings.setdefault("JobBatchName", job_name)
 
         for key, item in general_settings.items():

--- a/b2luigi/batch/processes/htcondor.py
+++ b/b2luigi/batch/processes/htcondor.py
@@ -119,11 +119,11 @@ class HTCondorProcess(BatchProcess):
       forget to actually set it up in your setup script.
       Additionally, you might want to copy your ``settings.json`` as well.
 
-    * You can give an ``htcondor_setting`` dict setting flag for additional options, such as
-      requested memory etc. It's value has to be a dictionary containing HTCondor settings as key/value pairs.
-      These options will be written into the job submission file.
-      For an overview of possible settings refer to the
-      `HTCondor documentation <https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html#>`_.
+    * Via the ``htcondor_settings`` :meth:`settings <b2luigi.set_setting>` you can provide a dict as
+      a for additional options, such as requested memory etc. Its value has to be a dictionary
+      containing HTCondor settings as key/value pairs. These options will be written into the job
+      submission file. For an overview of possible settings refer to the `HTCondor documentation
+      <https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html#>`_.
 
     Example:
 
@@ -213,7 +213,10 @@ class HTCondorProcess(BatchProcess):
 
             for transfer_file in transfer_files:
                 if os.path.abspath(transfer_file) != transfer_file:
-                    raise ValueError(f"You should only give absolute file names in transfer_files! {os.path.abspath(transfer_file)} != {transfer_file}")
+                    raise ValueError(
+                        "You should only give absolute file names in transfer_files!" +
+                        f"{os.path.abspath(transfer_file)} != {transfer_file}"
+                    )
 
             env_setup_script = get_setting("env_script", task=self.task, default="")
             if env_setup_script:

--- a/b2luigi/batch/processes/htcondor.py
+++ b/b2luigi/batch/processes/htcondor.py
@@ -98,7 +98,8 @@ class HTCondorProcess(BatchProcess):
 
     * Please note that most of the HTCondor batch farms do not have the same
       environment setup on submission and worker machines, so you probably want to give an
-      ``env_script``, an ``env`` setting and/or a different ``executable``.
+      ``env_script``, an ``env`` :meth:`setting <b2luigi.set_setting>` and/or a different ``executable``.
+
     * HTCondor supports copying files from submission to workers. This means if the
       folder of your script(s)/python project/etc. is not accessible on the worker, you can
       copy it from the submission machine by adding it to the setting ``transfer_files``.
@@ -119,7 +120,7 @@ class HTCondorProcess(BatchProcess):
       forget to actually set it up in your setup script.
       Additionally, you might want to copy your ``settings.json`` as well.
 
-    * Via the ``htcondor_settings`` :meth:`settings <b2luigi.set_setting>` you can provide a dict as
+    * Via the ``htcondor_settings`` setting you can provide a dict as
       a for additional options, such as requested memory etc. Its value has to be a dictionary
       containing HTCondor settings as key/value pairs. These options will be written into the job
       submission file. For an overview of possible settings refer to the `HTCondor documentation
@@ -128,7 +129,7 @@ class HTCondorProcess(BatchProcess):
     * Same as for the :ref:`LSF`, the ``job_name`` setting allows giving a meaningful name to a
       group of jobs. If you want to be htcondor-specific, you can provide the ``JobBatchName`` as an
       entry in the ``htcondor_settings`` dict, which will override the global ``job_name`` setting.
-      This is useful for checking the status of specific jobs with
+      This is useful for manually checking the status of specific jobs with
 
       .. code-block:: bash
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Nils Braun'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.5.1'
+release = '0.6.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/htcondor/settings.json
+++ b/examples/htcondor/settings.json
@@ -2,6 +2,7 @@
 	"batch_system": "htcondor",
 	"env_script": "setup_script.sh",
 	"executable": ["python3"],
+        "job_name": "b2luigi_example",
 	"htcondor_settings": {
 		"some": "settings",
 	}

--- a/tests/batch/test_htcondor_processs.py
+++ b/tests/batch/test_htcondor_processs.py
@@ -29,6 +29,23 @@ class TestHTCondorCreateSubmitFile(B2LuigiTestCase):
         with open(submit_file_path, "r") as submit_file:
             return submit_file.read()
 
+    def test_minimal_submit_file(self):
+        """
+        Minimal  submit file should have expected shape:
+
+            output = ...
+            error = ..
+            log = ..
+            executable = executable_wrapper.sh
+            queue 1
+        """
+        submit_file_lines = self._get_htcondor_submit_file_string(MyTask("some_parameter")).splitlines()
+        self.assertIn("output = ", submit_file_lines[0])
+        self.assertIn("error = ", submit_file_lines[1])
+        self.assertIn("log = ", submit_file_lines[2])
+        self.assertEqual("executable = executable_wrapper.sh", submit_file_lines[3])
+        self.assertEqual("queue 1", submit_file_lines[4])
+
     def test_not_setting_job_name(self):
         submit_file_string = self._get_htcondor_submit_file_string(MyTask("some_parameter"))
         self.assertNotIn("JobBatchName", submit_file_string)

--- a/tests/batch/test_htcondor_processs.py
+++ b/tests/batch/test_htcondor_processs.py
@@ -1,0 +1,59 @@
+"""
+Test helper functions for :py:class:`Gbasf2Process`.
+
+Utilities that require a running gbasf2 or Dirac environment will not net
+tested in this test case, only the functions that can be run independently.
+"""
+
+from b2luigi.batch.processes.htcondor import HTCondorProcess
+
+from ..helpers import B2LuigiTestCase
+from .batch_task_1 import MyTask
+from unittest.mock import Mock
+import os
+import b2luigi
+
+
+class TestHTCondorCreateSubmitFile(B2LuigiTestCase):
+
+    def _get_htcondor_submit_file_string(self, task):
+        # the _create_htcondor_submit_file is a method of the ``HTCondorProcess`` class, but it only uses its
+        # class to obtain ``self.task``, to it's sufficient to provide a mock class for ``self``, `
+        htcondor_mock_process = Mock()
+        task.get_task_file_dir = lambda: self.test_dir
+        htcondor_mock_process.task = task
+        #  create submit file
+        HTCondorProcess._create_htcondor_submit_file(htcondor_mock_process)
+        # read submit file and return string
+        submit_file_path = os.path.join(self.test_dir, "job.submit")
+        with open(submit_file_path, "r") as submit_file:
+            return submit_file.read()
+
+    def test_not_setting_job_name(self):
+        submit_file_string = self._get_htcondor_submit_file_string(MyTask("some_parameter"))
+        self.assertNotIn("JobBatchName", submit_file_string)
+
+    def test_set_job_name_via_task_attribute(self):
+        task = MyTask("some_parameter")
+        task.job_name = "some_job_name"
+        submit_file_lines = self._get_htcondor_submit_file_string(task).splitlines()
+        self.assertIn("JobBatchName = some_job_name", submit_file_lines)
+
+        b2luigi.set_setting("job_name", "some_job_name")
+        submit_file_lines = self._get_htcondor_submit_file_string(MyTask("some_parameter")).splitlines()
+        b2luigi.clear_setting("job_name")
+        self.assertIn("JobBatchName = some_job_name", submit_file_lines)
+
+    def test_set_job_name_is_overriden_by_htcondor_settings(self):
+        """
+        ``job_name`` is a global setting, but if the ``JobBatchName`` is set explicitly via the settings, we
+        want that to override the global setting
+        """
+        task = MyTask("some_parameter")
+        task.job_name = "job_name_global"
+        htcondor_settings = {"JobBatchName": "job_name_htcondor"}
+        b2luigi.set_setting("htcondor_settings", htcondor_settings)
+        submit_file_lines = self._get_htcondor_submit_file_string(task).splitlines()
+        b2luigi.clear_setting("htcondor_settings")
+        self.assertNotIn("JobBatchName = job_name_global", submit_file_lines)
+        self.assertIn("JobBatchName = job_name_htcondor", submit_file_lines)


### PR DESCRIPTION
In #76 the `job_name` setting was introduced to optionally set the `job_name` parameter for LSF jobs, to give groups of jobs a meaningful name for easier checking the status of specific jobs via the CLI. HTCondor has an equivalent `JobBatchName` setting which can already in previous versions be set via the `htcondor_settings` dictionary, but for consistency, this PR also makes htcondor observe the existing `job_name` setting.

## TODO's:
- [x] I just added the code, which was straightforward, but still need to run tests to see if it actually works.
- [x] Once I test the code, I also want to check if jobs get an default value for the job batch name automatically. If not, I could set this by default to the task class name, task id or the path to the executable wrapper, which seems to be the default for LSF jobs. 