### PR TITLE
import get_setting for lsf tasks

### DIFF
--- a/b2luigi/batch/processes/lsf.py
+++ b/b2luigi/batch/processes/lsf.py
@@ -7,7 +7,7 @@ from b2luigi.batch.processes import BatchProcess, JobStatus
 from b2luigi.batch.cache import BatchJobStatusCache
 from b2luigi.core.utils import get_log_file_dir
 from b2luigi.core.executable import create_executable_wrapper
-
+from b2luigi.core.settings import get_setting
 
 class LSFJobStatusCache(BatchJobStatusCache):
 


### PR DESCRIPTION
Hi, when we swtiched to get_setting for the ``queue`` and ``job_name`` parameter we did not add an import to use get_setting.

There is an extra problem in that for the ``queue`` and ``job_name`` parameter the default value is set to ``None``. However get_setting internally takes ``None`` to mean the setting is not defined and throws a ValueError. Should this be removed to allow for the default value to be ``None``?