### PR TITLE
Bump version: 0.6.0 → 0.6.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = True
 tag = True
 

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -1,5 +1,5 @@
 """Task scheduling and batch running for basf2 jobs made simple"""
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from luigi import *
 from luigi.util import inherits, copies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Nils Braun'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.6.0'
+release = '0.6.1'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Upps, release v0.6.0 didn't contain all PR's I wanted it to. I did the `bump2version` to v0.6.0 and the tag at the HEAD of the last PR that I merged into that release (#79), but that branch wasn't rebased to the head of main and didn't contain the LSF bugfix PR #81 and the gbasf2 feature PR #77 for supporting global tags. So this patch release includes those PRs and also it includes a fix to our PyPi publishing workflow (#82).
