### PR TITLE
Fix b2luigi __version__ being shadowed by luigi

### DIFF
--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -2,7 +2,8 @@
 from luigi import *
 from luigi.util import inherits, copies
 
-# version mast be defined importing luigi namespace, otherwise b2luigi.__version__ gives luigi version
+# version must be defined after importing the luigi namespace, 
+# otherwise the b2luigi.__version__ gets overwritten by the one from luigi
 __version__ = "0.6.3"
 
 from b2luigi.core.parameter import wrap_parameter, BoolParameter

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -1,8 +1,9 @@
 """Task scheduling and batch running for basf2 jobs made simple"""
-__version__ = "0.6.3"
-
 from luigi import *
 from luigi.util import inherits, copies
+
+# version mast be defined importing luigi namespace, otherwise b2luigi.__version__ gives luigi version
+__version__ = "0.6.3"
 
 from b2luigi.core.parameter import wrap_parameter, BoolParameter
 


### PR DESCRIPTION
The import statement
``` python
from luigi import *
```
also imports the `__version__` from luigi and this seems to shadow the b2luigi version defined at the top of the file.

The quick fix was to move the `__version__` definition down, but the best would be to no import the luigi version to begin with.

I found this when I checked `b2luigi.__version__` on a remote host to check the installed version and saw 3.0.2 as a result, which is the luigi version. I wonder why I didn't see this earlier...