### PR TITLE
HOTFIX: batch/processes/gbasf2.py: fix download command for failed files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.4
+current_version = 0.6.5
 commit = True
 tag = True
 

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -4,7 +4,7 @@ from luigi.util import inherits, copies
 
 # version must be defined after importing the luigi namespace,
 # otherwise the b2luigi.__version__ gets overwritten by the one from luigi
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 from b2luigi.core.parameter import wrap_parameter, BoolParameter
 

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -649,7 +649,8 @@ class Gbasf2Process(BatchProcess):
 
             # Any further time is based on the list of files from failed downloads
             else:
-                ds_get_command = shlex.split(f"gb2_ds_get --force --input_dslist {monitoring_failed_downloads_file}")
+                ds_get_command = shlex.split(f"gb2_ds_get --force {dataset_query_string} "
+                                             f"--input_dslist {monitoring_failed_downloads_file}")
                 print("Downloading remaining files from dataset with command ", " ".join(ds_get_command))
 
             stdout = run_with_gbasf2(ds_get_command, cwd=tmp_output_dir_path, capture_output=True).stdout

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Nils Braun'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.6.4'
+release = '0.6.5'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
The command requires the dataset query to work out. Otherwise error "too few arguments"