### PR TITLE
b2luigi/batch/processes/gbasf2.py: add additional required split

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -606,7 +606,8 @@ class Gbasf2Process(BatchProcess):
         Parse stdout from gb2_ds_get dataset download command to extract LFN's of failed file downloads.
         """
         failed_files = stdout.split('Failed files:')[-1].\
-            split("Files with duplicated jobID, not downloaded:")[0].strip().split('\n')
+            split("Files with duplicated jobID, not downloaded:")[0].\
+            split("Skip ")[0].strip().split('\n')
         failed_files = [line for line in failed_files if len(line.strip()) > 0]
         return failed_files
 

--- a/tests/batch/_gbasf2_project_download_stdouts/all_successful_and_skipped.txt
+++ b/tests/batch/_gbasf2_project_download_stdouts/all_successful_and_skipped.txt
@@ -1,7 +1,11 @@
 /local/dir/sub00 already exists
 
+Found valid local file for output/sub00/output_000001_job1234567890_01.root [Checksum matched: 23477d90]
+Skip to download the file...
+
 Download 1 files from SE
 Trying to download srm://srm-storage-element:8443/srm/managerv2?SFN=/pnfs/to/output/sub00/output_000001_job1234567890_00.root to /local/dir/sub00/output_000001_job1234567890_00.root
+
 
 Successfully downloaded files:
 /output/sub00/output_000001_job1234567890_00.root in /local/dir/sub00/output_000001_job1234567890_00.root
@@ -9,4 +13,5 @@ Successfully downloaded files:
 
 Failed files:
 
+Skip 1 existing files in /local/dir/sub00/
 

--- a/tests/batch/test_gbasf2_process.py
+++ b/tests/batch/test_gbasf2_process.py
@@ -42,6 +42,10 @@ class TestGbasf2FailedFilesDownload(B2LuigiTestCase):
         "Test gbasf2 project download output where all downloads are successful"
         self.assert_failed_files("all_successful.txt", 0)
 
+    def test_failed_files_all_successful_and_skipped(self):
+        "Test gbasf2 project download output where all downloads are successful, and some skiped due to local copy"
+        self.assert_failed_files("all_successful_and_skipped.txt", 0)
+
     def test_failed_files_all_successful_and_duplicate(self):
         "Test gbasf2 project download output where all downloads are successful, and duplicates available"
         self.assert_failed_files("all_successful_and_duplicate.txt", 0)


### PR DESCRIPTION
An addtional split of stdout is required for the case, when there are skipped files for download.

This is corrected now & a corresponding test is added.