### PR TITLE
Feature/improved warnings for incomplete gbasf2 download

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -596,9 +596,9 @@ class Gbasf2Process(BatchProcess):
         missing_files = list(set(output_dataset_basenames).difference(downloaded_dataset_basenames))
         superfluous_files = list(set(downloaded_dataset_basenames).difference(output_dataset_basenames))
         if missing_files:
-            print("\nFiles missing in download:\n{}".format("\n".join(missing_files)))
+            warnings.warn("\nFiles missing in download:\n{}".format("\n".join(missing_files)), RuntimeWarning)
         if superfluous_files:
-            print("\nFiles superfluous in download:\n{}".format("\n".join(superfluous_files)))
+            warnings.warn("\nFiles superfluous in download:\n{}".format("\n".join(superfluous_files)), RuntimeWarning)
         return False
 
     def _failed_files_from_dataset_download(self, stdout):


### PR DESCRIPTION
Basically I removed the `if verbose` and just always print missing/superfluous files if there are some.

I realized that I don't really need the verbose parameter and with the printing of difference implemented by @ArturAkh , it's also not necessary to print the list of all files. And anyway, if I can shorten code without any loss, it's better to do so.

Also I replaced the prints by warnings, though I would like to have this replaced by proper logging in #100 .

Resolves #101 