### PR TITLE
Added 'inherits_without' decorator to enable inheritance of everything except chosen parameters from task

### DIFF
--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -7,7 +7,7 @@ from luigi.util import inherits, copies
 __version__ = "0.6.6"
 
 from b2luigi.core.parameter import wrap_parameter, BoolParameter
-from typing import Union, Optional, Union
+from typing import Optional, Union, List
 
 wrap_parameter()
 
@@ -73,7 +73,6 @@ class requires(object):
 
 class inherits_without(object):
 
-
     def __init__(self, *tasks_to_inherit, without: Optional[Union[List, str]] = None):
         super(inherits_without, self).__init__()
         if not tasks_to_inherit:
@@ -85,7 +84,7 @@ class inherits_without(object):
         elif without is None:
             self.without = []
         else:
-            self.without =  without
+            self.without = without
 
     def __call__(self, task_that_inherits):
         # Get all parameter objects from each of the underlying tasks

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -74,7 +74,7 @@ class requires(object):
 class inherits(object):
 
     """
-    Similar to `b2luigi.requires`, this copies the luigi.inherits functionality but allows specifying parameters you
+    This copies the luigi.inherits functionality but allows specifying parameters you
     don't want to inherit.
 
     It can e.g. be used in tasks that merge the output of the tasks they require. These merger tasks don't need
@@ -107,6 +107,8 @@ class inherits(object):
 
     Parameters:
         without: Either a string or a collection of strings
+
+    See also: `b2luigi.requires` which extends ``luigi.requires``.
 
     """
 

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -138,7 +138,7 @@ class inherits(object):
                     self.without.remove(param_name)
 
         # Make sure we're only removing parameters that exist
-        assert len(self.without) == 0, f"You're trying to remove parameter(s) {self.without} which do(es) not exist."
+        assert not self.without, f"You're trying to remove parameter(s) {self.without} which do(es) not exist."
 
         # Modify task_that_inherits by adding methods
         def clone_parent(_self, **kwargs):

--- a/tests/core/test_requires.py
+++ b/tests/core/test_requires.py
@@ -39,3 +39,56 @@ class RequiresTestCase(B2LuigiTestCase):
         self.assertTrue(
             required_task.get_output_file_name("test.txt").endswith("results/some_parameter=3/some_other_parameter=1/test.txt")
         )
+
+
+class InheritsTestCase(B2LuigiTestCase):
+    def test_inherits(self):
+        class TaskA(b2luigi.Task):
+            some_parameter = b2luigi.IntParameter()
+            some_other_parameter = b2luigi.IntParameter()
+
+            def output(self):
+                yield self.add_to_output("test.txt")
+
+        @b2luigi.inherits(TaskA, without='some_other_parameter')
+        class TaskB(b2luigi.Task):
+            another_parameter = b2luigi.IntParameter()
+
+            def requires(self):
+                for my_other_parameter in range(10):
+                    yield self.clone(TaskA, some_other_parameter=my_other_parameter)
+
+            def run(self):
+                # somehow merge the output of TaskA to create "out.dat"
+                pass
+
+            def output(self):
+                yield self.add_to_output("out.dat")
+
+        task = TaskB(some_parameter=23, another_parameter=42)
+        self.assertEqual(task.get_param_names(), ["some_parameter", "another_parameter"])
+        self.assertEqual(task.another_parameter, 42)
+        self.assertEqual(task.some_parameter, 23)
+        self.assertFalse(hasattr(task, 'some_other_parameter'))
+
+        self.assertTrue(
+            task.get_output_file_name("out.dat").endswith("results/some_parameter=23/another_parameter=42/out.dat")
+        )
+
+        input_files = task.get_input_file_names("test.txt")
+        self.assertEqual(len(input_files), 10)
+        for my_other_parameter in range(10):
+            self.assertTrue(input_files[my_other_parameter]
+                            .endswith(f"results/some_parameter=23/some_other_parameter={my_other_parameter}/test.txt")
+                            )
+
+        required_tasks = list(task.requires())
+        for some_other_parameter_values, required_task in enumerate(required_tasks):
+            self.assertEqual(sorted(required_task.get_param_names()), ["some_other_parameter", "some_parameter"])
+            self.assertEqual(required_task.some_other_parameter, some_other_parameter_values)
+            self.assertEqual(required_task.some_parameter, 23)
+            self.assertTrue(
+                required_task
+                .get_output_file_name("test.txt")
+                .endswith(f"results/some_parameter=23/some_other_parameter={some_other_parameter_values}/test.txt")
+            )


### PR DESCRIPTION
Pretty much what it says on the tin. Maybe this could also replace the existing decorator, however I didn't want to introduce to many changes from stock luigi.

This feature is useful if you want to keep the same order of parameters (so the automatically-generated folders match between tasks) but maybe drop one or two parameters since you have resolved them (e.g. by merging files).

This is more or less a proposal, not necessarily a finished PR.