### PR TITLE
Update luigi scheduler progressbar for gbasf2 tasks

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -283,6 +283,12 @@ class Gbasf2Process(BatchProcess):
         n_failed = n_jobs_by_status["Failed"]
         n_in_final_state = n_done + n_failed
 
+        # try updating progressbar for central scheduler web view
+        try:
+            self.task.set_progress_percentage(n_done / n_jobs * 100)
+        except AttributeError:
+            pass
+
         # The gbasf2 project is considered as failed if any of the jobs in it failed.
         # However, we first try to reschedule thos jobs and only declare it as failed if the maximum number of retries
         # for reschedulinhas been reached
@@ -292,7 +298,14 @@ class Gbasf2Process(BatchProcess):
                 return JobStatus.running
             return JobStatus.aborted
 
+        # task is running
         if n_in_final_state < n_jobs:
+            # try updating progressbar for central scheduler web view
+            try:
+                percentage = n_done / n_jobs * 100
+                self._scheduler.set_task_progress_percentage(self.task.task_id, percentage)
+            except AttributeError:
+                pass
             return JobStatus.running
 
         # Require all jobs to be done for project success, any job failure results in a failed project

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -46,10 +46,11 @@ class Gbasf2Process(BatchProcess):
           task with the same project name is running, this b2luigi gbasf2 wrapper will recognize that
           and instead of resubmitting a new project, continue monitoring the running project.
 
-          Tipp: The outputs of gbasf2 tasks can be a bit overwhelming, so I recommend using the
-            :ref`Start a Central Scheduler <central scheduler>`
-            which features a nice overview in the browser, including progress bars showing how many jobs in each
-            project are already done.
+          .. hint::
+            The outputs of gbasf2 tasks can be a bit overwhelming, so I recommend using the
+            :ref:`central scheduler <central-scheduler-label>`
+            which provides a nice overview of all tasks in the browser, including a status/progress
+            indicator how many jobs in a gbasf2 project are already done.
 
         - **Automatic download of datasets and logs**
 

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -283,12 +283,6 @@ class Gbasf2Process(BatchProcess):
         n_failed = n_jobs_by_status["Failed"]
         n_in_final_state = n_done + n_failed
 
-        # try updating progressbar for central scheduler web view
-        try:
-            self.task.set_progress_percentage(n_done / n_jobs * 100)
-        except AttributeError:
-            pass
-
         # The gbasf2 project is considered as failed if any of the jobs in it failed.
         # However, we first try to reschedule thos jobs and only declare it as failed if the maximum number of retries
         # for reschedulinhas been reached

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -46,6 +46,11 @@ class Gbasf2Process(BatchProcess):
           task with the same project name is running, this b2luigi gbasf2 wrapper will recognize that
           and instead of resubmitting a new project, continue monitoring the running project.
 
+          Tipp: The outputs of gbasf2 tasks can be a bit overwhelming, so I recommend using the
+            :ref`Start a Central Scheduler <central scheduler>`
+            which features a nice overview in the browser, including progress bars showing how many jobs in each
+            project are already done.
+
         - **Automatic download of datasets and logs**
 
           If all jobs had been successful, it automatically downloads the output dataset and
@@ -295,11 +300,12 @@ class Gbasf2Process(BatchProcess):
         # task is running
         if n_in_final_state < n_jobs:
             # try updating progressbar for central scheduler web view
-            try:
-                percentage = n_done / n_jobs * 100
-                self._scheduler.set_task_progress_percentage(self.task.task_id, percentage)
-            except AttributeError:
-                pass
+            percentage = n_done / n_jobs * 100
+            self._scheduler.set_task_progress_percentage(self.task.task_id, percentage)
+
+            status_message = "\n".join(f"{status}: {n_jobs}" for status, n_jobs in n_jobs_by_status.items())
+            self._scheduler.set_task_status_message(self.task.task_id, status_message)
+
             return JobStatus.running
 
         # Require all jobs to be done for project success, any job failure results in a failed project

--- a/docs/documentation/run_modes.rst
+++ b/docs/documentation/run_modes.rst
@@ -51,6 +51,7 @@ Additional console arguments:
 *   **--scheduler-host** and **--scheduler-port**: If you have set up a central scheduler, you can pass this information
     here easily. This works for batch or non-batch submission but is turned of for the test mode.
 
+.. _central-scheduler-label:
 
 Start a Central Scheduler
 -------------------------


### PR DESCRIPTION
Since we now have luigi 3 as a dependency, we can make use of the progressbar-features for the scheduler. Here a small screenshot. The uppermost worker is a local merger task where I set the progressbar manually in its `run` method. The other progressbars are of gbasf2 tasks, each of which supervises a gbasf2 grid project consisting of many individual jobs. So for those, the progressbar that I implemented with this PR indicates how many of those jobs in that project are done. 
![grafik](https://user-images.githubusercontent.com/5121824/121616226-c7a4bc80-ca62-11eb-8945-580784c2e1cc.png)