### PR TITLE
tasks can return all input or all outputfiles with a single call

### DIFF
--- a/b2luigi/core/task.py
+++ b/b2luigi/core/task.py
@@ -76,6 +76,31 @@ class Task(luigi.Task):
             return file_paths[key]
         return file_paths
 
+    @staticmethod
+    def _transform_output(output_generator, key=None):
+        output_list = utils.flatten_to_list_of_dicts(output_generator)
+        file_paths = utils.flatten_to_file_paths(output_list)
+
+        if key is not None:
+            return file_paths[key]
+        return file_paths
+
+    def get_all_output_file_names(self):
+        """
+        Return all file paths created by this task
+        """
+        for file_name_key in self._transform_output(self.output()):
+            for file_name in self._transform_output(file_name_key):
+                yield self.get_output_file_name(file_name)
+
+    def get_all_input_file_names(self):
+        """
+        Return all file paths requiered by this task
+        """
+        for file_name_key in self.get_input_file_names():
+            for file_name in self.get_input_file_names(file_name_key):
+                yield file_name
+
     def get_input_file_names(self, key=None):
         """
         Get a dictionary of input file names of the tasks, which are defined in our requirements.

--- a/b2luigi/core/task.py
+++ b/b2luigi/core/task.py
@@ -62,8 +62,6 @@ class Task(luigi.Task):
             output_file_name (:obj:`str`): the file name of the output file.
                 Refer to this file name as a key when using :obj:`get_input_file_names`,
                 :obj:`get_output_file_names` or :obj:`get_output_file`.
-
-
         """
         return {output_file_name: self._get_output_file_target(output_file_name)}
 
@@ -76,29 +74,18 @@ class Task(luigi.Task):
             return file_paths[key]
         return file_paths
 
-    @staticmethod
-    def _transform_output(output_generator, key=None):
-        output_list = utils.flatten_to_list_of_dicts(output_generator)
-        file_paths = utils.flatten_to_file_paths(output_list)
-
-        if key is not None:
-            return file_paths[key]
-        return file_paths
-
-    def get_all_output_file_names(self):
-        """
-        Return all file paths created by this task
-        """
-        for file_name_key in self._transform_output(self.output()):
-            for file_name in self._transform_output(file_name_key):
-                yield self.get_output_file_name(file_name)
-
     def get_all_input_file_names(self):
         """
-        Return all file paths requiered by this task
+        Return all file paths required by this task.
+
+        Example:
+            class TheSuperFancyTask(b2luigi.Task):
+                def dry_run(self):
+                    for name in self.get_all_output_file_names():
+                        print(f"\t\toutput:\t{name}")
         """
-        for file_name_key in self.get_input_file_names():
-            for file_name in self.get_input_file_names(file_name_key):
+        for file_name_key, file_names in self.get_input_file_names().items():
+            for file_name in file_names:
                 yield file_name
 
     def get_input_file_names(self, key=None):
@@ -164,6 +151,29 @@ class Task(luigi.Task):
             Else, returns only the list of file paths for this given key.
         """
         return self._transform_input(self.input()[requirement_key], key)
+
+    @staticmethod
+    def _transform_output(output_generator, key=None):
+        output_list = utils.flatten_to_list_of_dicts(output_generator)
+        file_paths = utils.flatten_to_file_paths(output_list)
+
+        if key is not None:
+            return file_paths[key]
+        return file_paths
+
+    def get_all_output_file_names(self):
+        """
+        Return all file paths created by this task.
+
+        Example:
+            class TheSuperFancyTask(b2luigi.Task):
+                def dry_run(self):
+                    for name in self.get_all_output_file_names():
+                        print(f"\t\toutput:\t{name}")
+        """
+        for file_name_key, file_names in self._transform_output(self.output()).items():
+            for file_name in file_names:
+                yield file_name
 
     def get_output_file_name(self, key):
         """

--- a/b2luigi/core/task.py
+++ b/b2luigi/core/task.py
@@ -84,7 +84,7 @@ class Task(luigi.Task):
                     for name in self.get_all_output_file_names():
                         print(f"\t\toutput:\t{name}")
         """
-        for file_name_key, file_names in self._transform_input(self.input()).items():
+        for file_names in self._transform_input(self.input()).values():
             for file_name in file_names:
                 yield file_name
 
@@ -171,7 +171,7 @@ class Task(luigi.Task):
                     for name in self.get_all_output_file_names():
                         print(f"\t\toutput:\t{name}")
         """
-        for file_name_key, file_names in self._transform_output(self.output()).items():
+        for file_names in self._transform_output(self.output()).values():
             for file_name in file_names:
                 yield file_name
 

--- a/b2luigi/core/task.py
+++ b/b2luigi/core/task.py
@@ -84,7 +84,7 @@ class Task(luigi.Task):
                     for name in self.get_all_output_file_names():
                         print(f"\t\toutput:\t{name}")
         """
-        for file_name_key, file_names in self.get_input_file_names().items():
+        for file_name_key, file_names in self._transform_input(self.input()).items():
             for file_name in file_names:
                 yield file_name
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -2,7 +2,7 @@ from ..helpers import B2LuigiTestCase
 
 import b2luigi
 from b2luigi.core.utils import get_filled_params
-from pathlib import Path
+
 
 class TaskTestCase(B2LuigiTestCase):
     def test_file_path_usage(self):
@@ -39,7 +39,7 @@ class TaskTestCase(B2LuigiTestCase):
                 yield self.add_to_output("file_b")
 
         task = TaskB(some_parameter=42)
-       
+
         self.assertEqual(get_filled_params(task), {"some_parameter": 42})
         self.assertEqual(len(task._get_input_targets("file_a")), 1)
         self.assertEqual(len(task.get_input_file_names("file_a")), 1)
@@ -48,9 +48,9 @@ class TaskTestCase(B2LuigiTestCase):
         self.assertEqual(task._get_output_target("file_b").path, task.get_output_file_name("file_b"))
         self.assertIn("file_b", task.get_output_file_name("file_b"))
         self.assertIn("some_parameter=42", task.get_output_file_name("file_b"))
-        self.assertIn("some_parameter=42/file_a",list(task.get_all_input_file_names())[0])
-        self.assertIn("some_parameter=42/file_b",list(task.get_all_output_file_names())[0])
- 
+        self.assertIn("some_parameter=42/file_a", list(task.get_all_input_file_names())[0])
+        self.assertIn("some_parameter=42/file_b", list(task.get_all_output_file_names())[0])
+
     def test_many_dependencies(self):
         class TaskA(b2luigi.Task):
             some_parameter = b2luigi.IntParameter()
@@ -78,4 +78,3 @@ class TaskTestCase(B2LuigiTestCase):
 
         for i in range(100):
             self.assertIn(f"results/some_parameter={i}/file_a", input_file_names)
-

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -48,6 +48,8 @@ class TaskTestCase(B2LuigiTestCase):
         self.assertEqual(task._get_output_target("file_b").path, task.get_output_file_name("file_b"))
         self.assertIn("file_b", task.get_output_file_name("file_b"))
         self.assertIn("some_parameter=42", task.get_output_file_name("file_b"))
+        self.assertEqual(len(list(task.get_all_input_file_names())), 1)
+        self.assertEqual(len(list(task.get_all_output_file_names())), 1)
         self.assertIn("some_parameter=42/file_a", list(task.get_all_input_file_names())[0])
         self.assertIn("some_parameter=42/file_b", list(task.get_all_output_file_names())[0])
 

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -2,7 +2,7 @@ from ..helpers import B2LuigiTestCase
 
 import b2luigi
 from b2luigi.core.utils import get_filled_params
-
+from pathlib import Path
 
 class TaskTestCase(B2LuigiTestCase):
     def test_file_path_usage(self):
@@ -39,7 +39,7 @@ class TaskTestCase(B2LuigiTestCase):
                 yield self.add_to_output("file_b")
 
         task = TaskB(some_parameter=42)
-
+       
         self.assertEqual(get_filled_params(task), {"some_parameter": 42})
         self.assertEqual(len(task._get_input_targets("file_a")), 1)
         self.assertEqual(len(task.get_input_file_names("file_a")), 1)
@@ -48,7 +48,9 @@ class TaskTestCase(B2LuigiTestCase):
         self.assertEqual(task._get_output_target("file_b").path, task.get_output_file_name("file_b"))
         self.assertIn("file_b", task.get_output_file_name("file_b"))
         self.assertIn("some_parameter=42", task.get_output_file_name("file_b"))
-
+        self.assertIn("some_parameter=42/file_a",list(task.get_all_input_file_names())[0])
+        self.assertIn("some_parameter=42/file_b",list(task.get_all_output_file_names())[0])
+ 
     def test_many_dependencies(self):
         class TaskA(b2luigi.Task):
             some_parameter = b2luigi.IntParameter()
@@ -76,3 +78,4 @@ class TaskTestCase(B2LuigiTestCase):
 
         for i in range(100):
             self.assertIn(f"results/some_parameter={i}/file_a", input_file_names)
+


### PR DESCRIPTION
Hey guys, I added some functionalities to get with a single call all input or all output files of a task. For me this is a very nice debugging feature, using this together with the `dry_run` method.

```
class TheSuperFancyTask(b2luigi.Task):
    def dry_run(self):
        for name in self.get_all_input_file_names(): 
            print(f"\t\tinput:\t{name}") 
        for name in self.get_all_output_file_names(): 
            print(f"\t\toutput:\t{name}")
[....]
```
Producing s.th. like 
```
MainTask                                                                                                                                                    [750/1824]
        Would run TheSuperFancyTask()
        call: dry_run()
                input:  /path/to/file/a
                input:  /path/to/file/b
                input:  /path/to/file/xyz
                output: /path/to/output/1
                output: /path/to/output/n 
```
when running in dry-run mode. 

I know having several output files is not best practice, but if you have it and want to debug it fast, you have here some nice feature as well.

Are you interested?