### PR TITLE
Workaround for basf2 externals 10 ROOT memory error

### DIFF
--- a/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
+++ b/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
@@ -10,7 +10,7 @@ def get_alias_dict_from_variable_manager():
     Extracts a dictionary with the alias names as keys and their values from the
     internal state of the variable manager and returns it.
     """
-    alias_dictionary = {alias_name: vm.getVariable(alias_name).name for alias_name in list(vm.getAliasNames())}
+    alias_dictionary = {str(alias_name): vm.getVariable(str(alias_name)).name for alias_name in vm.getAliasNames()}
     return alias_dictionary
 
 


### PR DESCRIPTION
`vm.getAliasNames` returns a `std::vector<string>`, which in the ROOT version from the basf2 externals v10 needs to be explicitly converted to python strings (`str`), otherwise we get memory errors due to the C++ object lifetime. See [1] and [2].

[1]: https://agira.desy.de/browse/BII-8572
[2]: https://questions.belle2.org/question/11333/interplay-between-c-stdvector-and-lists-in-python-with-new-externals-v01-10-00/

This solves issue #114 reported by @dferlewicz 