### PR TITLE
Give instances of `MasterTask` in doc examples less sensitive names

### DIFF
--- a/docs/advanced/basf2-examples.rst
+++ b/docs/advanced/basf2-examples.rst
@@ -141,14 +141,14 @@ nTuple Generation
             return path
 
 
-    class MasterTask(luigi.WrapperTask):
+    class AnalysisWrapperTask(luigi.WrapperTask):
         def requires(self):
             # somehow loop over the runs, experiment etc.
                 yield self.clone(AnalysisTask, experiment_number=...)
 
 
     if __name__ == "__main__":
-        luigi.process(MasterTask(), workers=500)
+        luigi.process(AnalysisWrapperTask(), workers=500)
 
 
 Standard Simulation, Reconstruction and some nTuple Generation

--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -97,7 +97,7 @@ class AnalysisTask(Basf2PathTask):
         yield self.add_to_output("B_n_tuple.root")
 
 
-class MasterTask(Basf2nTupleMergeTask):
+class MainTask(Basf2nTupleMergeTask):
     n_events = luigi.IntParameter()
 
     def requires(self):
@@ -106,4 +106,4 @@ class MasterTask(Basf2nTupleMergeTask):
 
 
 if __name__ == "__main__":
-    luigi.process(MasterTask(n_events=1), workers=4)
+    luigi.process(MainTask(n_events=1), workers=4)

--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -97,7 +97,7 @@ class AnalysisTask(Basf2PathTask):
         yield self.add_to_output("B_n_tuple.root")
 
 
-class MainTask(Basf2nTupleMergeTask):
+class AggregatorTask(Basf2nTupleMergeTask):
     n_events = luigi.IntParameter()
 
     def requires(self):
@@ -106,4 +106,4 @@ class MainTask(Basf2nTupleMergeTask):
 
 
 if __name__ == "__main__":
-    luigi.process(MainTask(n_events=1), workers=4)
+    luigi.process(AggregatorTask(n_events=1), workers=4)

--- a/examples/gbasf2/gbasf2_example.py
+++ b/examples/gbasf2/gbasf2_example.py
@@ -4,7 +4,7 @@ from b2luigi.basf2_helper.tasks import Basf2PathTask
 import example_mdst_analysis
 
 
-class MyAnalysisTask(Basf2PathTask):
+class AnalysisTask(Basf2PathTask):
     # set the batch_system property to use the gbasf2 wrapper batch process for this task
     batch_system = "gbasf2"
     # Must define a prefix for the gbasf2 project name to submit to the grid.
@@ -27,9 +27,9 @@ class MyAnalysisTask(Basf2PathTask):
         yield self.add_to_output("B_ntuple.root")
 
 
-class MasterTask(b2luigi.WrapperTask):
+class AnalysisWrapperTask(b2luigi.WrapperTask):
     """
-    We use the MasterTask to be able to require multiple analyse tasks with
+    We use the AnalysisWrapperTask to be able to require multiple analyse tasks with
     different input datasets and cut values. For each parameter combination, a
     different gbasf2 project will be submitted.
     """
@@ -41,7 +41,7 @@ class MasterTask(b2luigi.WrapperTask):
         # if you want to iterate over different cuts, just add more values to this list
         mbc_lower_cuts = [5.15, 5.2]
         for mbc_lower_cut in mbc_lower_cuts:
-            yield MyAnalysisTask(
+            yield AnalysisTask(
                 mbc_lower_cut=mbc_lower_cut,
                 gbasf2_project_name_prefix="luigiExample",
                 gbasf2_input_dataset=input_dataset,
@@ -50,6 +50,6 @@ class MasterTask(b2luigi.WrapperTask):
 
 
 if __name__ == '__main__':
-    main_task_instance = MasterTask()
+    main_task_instance = AnalysisWrapperTask()
     n_gbasf2_tasks = len(list(main_task_instance.requires()))
     b2luigi.process(main_task_instance, workers=n_gbasf2_tasks)


### PR DESCRIPTION
I already mentioned the rationale in #117 . I think it would be more appropriate to use other task names than `MasterTask`, which doesn't convey much meaning anyway. In one instance I named it `MainTask`, similar to how we renamed the main branch name in #39. But since we are implementing `luigi.WrapperTask`, it might be more meaningful to encode what is being wrapped in the name, e.g. `AnalysisWrapperTask`, which I used in the other two occurances.

This is just a documentation change, but I think it is important because the examples are how we present b2luigi, it's the first of b2luigi that new users see and often they just adopt the naming from the examples.

It's not urgent, so can wait for a comment from @nils-braun who did the branch renaming in #39, maybe you have some ideas with regards to proper naming.