### PR TITLE
Bugfix: Don't use deprecated exception messsage property

### DIFF
--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -279,8 +279,8 @@ def map_folder(input_folder):
         raise type(ex)(
             "Could not determine the current script location. "
             "If you are running in an interactive shell (such as jupyter notebook) "
-            "make sure to only provide absolute paths in your settings.\nMore Info:\n" +
-            ex.message
+            "make sure to only provide absolute paths in your settings. "
+            f"More Info:\n{ex}"
         ).with_traceback(sys.exc_info()[2])
 
     filepath = os.path.dirname(filename)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,4 +1,5 @@
-from unittest import TestCase
+import os
+from unittest import TestCase, mock
 
 from b2luigi.core import utils
 
@@ -145,3 +146,82 @@ class FlattenTestCase(TestCase):
         self.assertEqual(outputs["key1"], ["value1", "repeated"])
         self.assertIn("key2", outputs)
         self.assertEqual(outputs["key2"], ["value2"])
+
+
+class MapFolderTestCase(TestCase):
+    dummy_rel_dir = "./some/rel_dir"
+    dummy_abs_dir = "/path/to/some/abs_dir"
+    main_no_file_file_err_msg = "module '__main__' has no attribute '__file__'"
+
+    def test_map_folder_abspath_identity(self):
+        """Test that for an absolute path, map_folder returns and identity"""
+        self.assertEqual(utils.map_folder(self.dummy_abs_dir), self.dummy_abs_dir)
+
+    def test_map_folder_relpath(self):
+        """
+        Test map_folder with a relative input_folder, which joins it with ``__main__.__file__``
+        """
+        with mock.patch("__main__.__file__", self.dummy_abs_dir):
+            mapped_folder = utils.map_folder(self.dummy_rel_dir)
+            self.assertEqual(
+                mapped_folder, os.path.join(self.dummy_abs_dir, mapped_folder)
+            )
+
+    def test_map_folder_abspath_identity_when_no_filename(self):
+        """
+        Test that for an absolute path, map_folder returns and identity even
+        if ``get_filename`` would raise an ``AttributeError`` because ``__main__.__file__``
+        is not available (e.g. in jupyter)
+        """
+        with mock.patch(
+            "b2luigi.core.utils.get_filename",
+            side_effect=AttributeError(self.main_no_file_file_err_msg),
+        ):
+            mapped_folder = utils.map_folder(self.dummy_abs_dir)
+            self.assertEqual(mapped_folder, self.dummy_abs_dir)
+
+    def test_map_folder_raises_attribute_error_for_relpath_when_no_filename(self):
+        """
+        Test that when ``get_filename`` returns an ``AttributeError`` b/c
+        ``__main__.__file__`` is not available, ``map_folder`` also returns an
+        ``AttributeError`` when the input folder is relative
+        """
+        with self.assertRaises(AttributeError):
+            with mock.patch(
+                "b2luigi.core.utils.get_filename",
+                side_effect=AttributeError(self.main_no_file_file_err_msg),
+            ):
+                utils.map_folder(self.dummy_rel_dir)
+
+    def _get_map_folder_error_mesage(self):
+        """
+        Get the error message that ``map_folder`` raises when ``get_filename``
+        raises an attribute error because ``__main__.__file__`` is not
+        accessible (e.g. in Jupyter)
+        """
+        try:
+            with mock.patch(
+                "b2luigi.core.utils.get_filename",
+                side_effect=AttributeError(self.main_no_file_file_err_msg),
+            ):
+                utils.map_folder(self.dummy_rel_dir)
+        except AttributeError as err:
+            return str(err)
+        raise RuntimeError("No AttributeError raised when calling ``utils.map_folder``")
+
+    def test_original_message_in_error(self):
+        """
+        Check that the error message of ``map_folder`` still contains the
+        original error message raised by ``get_filename`` during an
+        ``AttributeError`` due to ``__main__.__file__`` not being accessible
+        """
+        message = self._get_map_folder_error_mesage()
+        self.assertTrue(message.endswith(self.main_no_file_file_err_msg))
+
+    def test_additional_info_added_to_error(self):
+        """
+        Check that the error message of ``map_folder`` adds additional
+        information to the ``AttributeError`` raised by ``get_filename``
+        """
+        message = self._get_map_folder_error_mesage()
+        self.assertTrue(message.startswith("Could not determine the current script location. "))


### PR DESCRIPTION
That property is deprecated since python 2.6, see PEP-352 [1].

Solves #119

[1]: https://www.python.org/dev/peps/pep-0352/#retracted-ideas
