### PR TITLE
Fix gbasf2 batch example for new basf2 releases: import ROOT

### DIFF
--- a/examples/gbasf2/example_mdst_analysis.py
+++ b/examples/gbasf2/example_mdst_analysis.py
@@ -5,6 +5,7 @@ analysis path be imported from gbasf2_example.py
 """
 
 import basf2
+import ROOT
 import modularAnalysis as mA
 import vertex as vx
 from stdCharged import stdK, stdPi

--- a/examples/gbasf2/settings.json
+++ b/examples/gbasf2/settings.json
@@ -3,5 +3,5 @@
     "gbasf2_print_status_updates": true,
     "gbasf2_max_retries": 0,
     "gbasf2_cputime": 5,
-    "gbasf2_download_logs": true
+    "gbasf2_download_logs": false
 }


### PR DESCRIPTION
If ROOT is not explicitly imported, the example fails for the light-2106-rhea release, at least for me. Because the stdCharged packages try to import something from the ROOT namespace, but python complains that such a package does not exist. Explicitly importing ROOT fixes this. Not sure if that's also a problem for future basf2 releases or a bug in basf2.