### PR TITLE
Ignore flake8 error for unused ROOT import

### DIFF
--- a/examples/gbasf2/example_mdst_analysis.py
+++ b/examples/gbasf2/example_mdst_analysis.py
@@ -5,7 +5,7 @@ analysis path be imported from gbasf2_example.py
 """
 
 import basf2
-import ROOT
+import ROOT  # noqa: F401
 import modularAnalysis as mA
 import vertex as vx
 from stdCharged import stdK, stdPi


### PR DESCRIPTION
The ROOT import is necessary, other stdCharged cannot be imported, since the import packages from the ROOT namespace. However, flake8 doesn't know about this and this caused pre-commit to complain.