### PR TITLE
Test `ignore_additional_command_line_args` option

### DIFF
--- a/tests/cli/process_with_user_args_ignored_by_b2luigi.py
+++ b/tests/cli/process_with_user_args_ignored_by_b2luigi.py
@@ -1,0 +1,40 @@
+import argparse
+
+import b2luigi
+
+
+class AlwaysExistingTarget(b2luigi.Target):
+    """
+    Target that always exists
+    """
+
+    def exists(self):
+        return True
+
+
+class DoNothingTask(b2luigi.ExternalTask):
+    """
+    Dummy task that is always already complete and needs nothing to be done.
+
+    Useful for testing ``b2luigi.process`` just for its CLI argument parsing
+    with some dummy task.
+    """
+
+    def output(self):
+        return AlwaysExistingTarget()
+
+
+if __name__ == "__main__":
+    # add some dummy user args. They should work with the ignore_additional_command_line_args option
+    parser = argparse.ArgumentParser("")
+    parser.add_argument("--hello", help="Keyword argument, should be ``'world'``")
+    parser.add_argument("is_one", help="First positional argument, should be ``1``")
+    parser.add_argument("is_two", help="Second positional argument, should be ``2``")
+    args = parser.parse_args()
+    # check that none of the args is None
+    assert args.hello == "world", "--hello should be `world`"
+    assert int(args.is_one) == 1, "first positional arg should be 1"
+    assert int(args.is_two) == 2, "second positional arg should be 2"
+    # process task that does nothing. b2luigi.process parses its own cli args,
+    # but with the ignore option that should not result in collisions
+    b2luigi.process(DoNothingTask(), ignore_additional_command_line_args=True)

--- a/tests/cli/process_with_user_args_not_ignored_by_b2luigi.py
+++ b/tests/cli/process_with_user_args_not_ignored_by_b2luigi.py
@@ -1,0 +1,26 @@
+import b2luigi
+
+
+class AlwaysExistingTarget(b2luigi.Target):
+    """
+    Target that always exists
+    """
+
+    def exists(self):
+        return True
+
+
+class DoNothingTask(b2luigi.ExternalTask):
+    """
+    Dummy task that is always already complete and needs nothing to be done.
+
+    Useful for testing ``b2luigi.process`` just for its CLI argument parsing
+    with some dummy task.
+    """
+
+    def output(self):
+        return AlwaysExistingTarget()
+
+
+if __name__ == "__main__":
+    b2luigi.process(DoNothingTask(), ignore_additional_command_line_args=False)

--- a/tests/cli/test_ignore_additional_command_line_args.py
+++ b/tests/cli/test_ignore_additional_command_line_args.py
@@ -1,0 +1,13 @@
+from ..helpers import B2LuigiTestCase
+
+
+class TestIgnoreAdditionalCommandLineArgs(B2LuigiTestCase):
+    def test_accept_user_args_if_ignored_by_b2luigi(self):
+        """
+        Check that we can use our own CLI args in scripts if
+        ``ignore_additional_command_line_args`` is ``True``, which means they
+        should be ignore by ``b2luigi.process``.
+        """
+        self.call_file(
+            "cli/process_with_user_args_ignored_by_b2luigi.py", cli_args=["--hello", "world", "1", "2"]
+        )

--- a/tests/cli/test_ignore_additional_command_line_args.py
+++ b/tests/cli/test_ignore_additional_command_line_args.py
@@ -1,3 +1,4 @@
+from subprocess import CalledProcessError
 from ..helpers import B2LuigiTestCase
 
 
@@ -9,5 +10,17 @@ class TestIgnoreAdditionalCommandLineArgs(B2LuigiTestCase):
         should be ignore by ``b2luigi.process``.
         """
         self.call_file(
-            "cli/process_with_user_args_ignored_by_b2luigi.py", cli_args=["--hello", "world", "1", "2"]
+            "cli/process_with_user_args_ignored_by_b2luigi.py",
+            cli_args=["--hello", "world", "1", "2"],
         )
+
+    def test_user_args_when_not_ignored_raises_error(self):
+        """
+        Check that we can't use undefined CLI args in scripts if
+        ``ignore_additional_command_line_args=False`` in ``b2luigi.process.
+        """
+        with self.assertRaises(CalledProcessError):
+            self.call_file(
+                "cli/process_with_user_args_not_ignored_by_b2luigi.py",
+                cli_args=["--hello", "world"],
+            )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,10 +21,12 @@ class B2LuigiTestCase(TestCase):
         os.chdir(self.cwd)
         shutil.rmtree(self.test_dir)
 
-    def call_file(self, file_name, cwd=None, **kwargs):
+    def call_file(self, file_name, cwd=None, cli_args=None, **kwargs):
         if not cwd:
             cwd = self.test_dir
+        if not cli_args:
+            cli_args = []
         test_file_name = os.path.join(os.path.dirname(__file__), file_name)
         tmp_file_name = os.path.join(self.test_dir, os.path.basename(file_name))
         shutil.copy(test_file_name, tmp_file_name)
-        return subprocess.check_output([sys.executable, tmp_file_name], cwd=cwd, **kwargs)
+        return subprocess.check_output([sys.executable, tmp_file_name, *cli_args], cwd=cwd, **kwargs)


### PR DESCRIPTION
Tests for the ` `ignore_additional_command_line_args` option to `b2luigi.process` introduced in #55 by @klieret. Then I will have more peace of mind when people claim to have issues with this option.

If `ignore_additional_command_line_args=True`, `b2luigi.process` should allow additional command line args not known to b2luigi, as they might be used by the user script. Otherwise, only b2luigi cli args should be allowed.

In this PR there is a bit of boilerplate code due to `DoNothingTask` being defined twice in two test-scripts. Somehow I had issues with using relative import in the test-directory since it's not a package. Originally I had them in a `cli_tasks.py` file in the same directory and imported them with
``` python
from .cli_tasks import DoNothingTask
```
But this didn't work when running the unit tests. Not sure why that is not working but `import ..helpers` works, maybe I should add an `__init__.py` or something like that?  Maybe @nils-braun or someone else knows?

