### PR TITLE
Add Artur Gottmann to contributors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -132,6 +132,7 @@ Features, fixing, help and testing
     * Phil Grace (`philiptgrace`_)
     * Anselm Baur (`anselmbaur`_)
     * Moritz Bauer (`sognetic`_)
+    * Artur Gottmann (`ArturAkh`_)
 
 Stolen ideas
     * Implementation of SGE batch system (`sge`_).
@@ -151,6 +152,7 @@ Stolen ideas
 .. _`philiptgrace`: https://github.com/philiptgrace
 .. _`anselmbaur`: https://github.com/anselm-baur
 .. _`sognetic`: https://github.com/sognetic
+.. _`ArturAkh`: https://github.com/ArturAkh
 .. _`sge`: https://github.com/spotify/luigi/blob/master/luigi/contrib/sge.py
 .. _`lsf`: https://github.com/spotify/luigi/pull/2373/files
 


### PR DESCRIPTION
I just notided I haven't added @ArturAkh to the [contributors list](https://b2luigi.readthedocs.io/en/stable/#the-team) in the documentation yet, so I let's add him if he isn't against it
![grafik](https://user-images.githubusercontent.com/5121824/136976768-04d884ac-14b4-47cc-89f0-3645d1de489e.png)
