### PR TITLE
Fix gb2_proxy_init error due to wrong HOME from gbasf2 setup script

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -928,6 +928,10 @@ def get_gbasf2_env(gbasf2_install_directory=None):
         echo_gbasf2_env_command, check=True, stdout=subprocess.PIPE, encoding="utf-8"
     ).stdout
     gbasf2_env = dict(line.split("=", 1) for line in gbasf2_env_string.splitlines())
+    # The gbasf2 setup script on sets HOME to /ext/home/ueda if it's unset,
+    # which later causes problems in the gb2_proxy_init subprocess. Therefore,
+    # reset it to the caller's HOME.
+    gbasf2_env["HOME"] = os.getenv("HOME")
     return gbasf2_env
 
 


### PR DESCRIPTION
The gbasf2 setup script on sets `HOME` to `/ext/home/ueda` if it's initally unset
(as is the case due to our `env -i`), which later causes problems in the
`gb2_proxy_init` subprocess, as it searches for the certificates in Ueda-San's
`HOME`. Therefore, reset it to the caller's `HOME`.

Resolves #138