### PR TITLE
Update `README.rst`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ If you find any bugs or want to add a feature or improve the documentation, plea
 This project is in still beta. Please be extra cautious when using in production mode.
 
 To get notified about new features, (potentiall breaking) changes, bugs and
-their fixes, I recommend using the ``watch`` button on github to get
+their fixes, I recommend using the ``Watch`` button on github to get
 notifications for new releases and/or issues or to subscribe the `releases feed
 <https://github.com/nils-braun/b2luigi/releases.atom>`_ (requires no github
 account, just a feed reader).


### PR DESCRIPTION
- Add instructions how to subscribe to releases via github `watch` or atom feed. I often write important information there and since is beta and things often break, I think it might help for power users to subscribe to that

- Add HTCondor next to LSF to example of supported batches in the README, since it is widely used and we should advertise that. Gbasf2/Grid is not added because it is a soft wrapper and doesn't support arbitrary tasks and explaining that would take to long in the readme

- small grammar fixes