### PR TITLE
Add a `CHANGELOG.md` file generated from github releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Older entries have been generated from github releases.
 New entries aim to adhere to the format proposed by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.7.3] - 2021-10-21
 Small patch release for the gbasf2 process adding tests and better error checks for subprocess to make future debugging of problems like e.g. #138 easier
 

--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -77,7 +77,9 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
     the created docs now (most likely http://127.0.0.1:8000).
     Please make sure the documentation looks fine before creating a pull request.
 
-6.  If you are a core developer and want to release a new version:
+7.  Add a summary of your changes to the ``[Unreleased]`` section of the ``CHANGELOG.md``.
+
+8.  If you are a core developer and want to release a new version:
 
     a.  Make sure all changes are committed and merged on main
     b.  Use the `bump2version`_ package to update the version in the python file ``b2luigi/__init__.py`` as well
@@ -94,9 +96,11 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
             git push
             git push --tags
 
-    d.  Create a new `release`_ with a description on github
+    d.  Update the ``CHANGELOG.md`` following the `Keep a Changelog`_ format.
 
-    e. Check that the new release had been published to PyPi, which should happen automatically via
+    e.  Create a new `release`_ on github, with the description copied from the ``CHANGELOG.md``.
+
+    f. Check that the new release had been published to PyPi, which should happen automatically via
        github `actions`_. Alternatively, you can also manually publish a release via
 
         .. code-block:: bash
@@ -120,3 +124,4 @@ welcome, so feel free to pick one, e.g. with the ``good first issue`` or ``help 
 .. _bump2version: https://github.com/c4urself/bump2version
 .. _release: https://github.com/nils-braun/b2luigi/releases
 .. _actions: https://github.com/nils-braun/b2luigi/actions
+.. _Keep a Changelog: https://keepachangelog.com/en/1.0.0/


### PR DESCRIPTION
Try to adhere loosely to the format from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) for the newer releases.

To generate the `CHANGELOG.md` from github releases, I used [github-release-notes](https://github.com/github-tools/github-release-notes) (gren)  with the following custom template in my `.grenrc.js` (see [gren options docs]( https://github-tools.github.io/github-release-notes/options.html)):

``` js
module.exports = {
    "template": {
        "release": function (placeholders) {
            // change date format to YY-mm-dd
            [day, month, year] = placeholders.date.split("/")
            iso_date = `${year}-${month}-${day}`
            // remove leading "v" from release
            release = placeholders.release.replace("v", "")
            return `## [${release}] - ${iso_date}\n${placeholders.body}`
        }
    }
}
```

This still looked bad because some github release notes had markdown headings which were h2 (`##`) or lower, hower `##` is used by gren for release headings. So I hand-edited the `CHANGELOG.md` to adapt some heading levels and in the process also changed the newer releases to adhere more closely to the keepachangelog format.

Closes #145 