### PR TITLE
Gbasf2: Fix moving of downloaded multi-sub datasets

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -656,7 +656,7 @@ class Gbasf2Process(BatchProcess):
             os.makedirs(tmp_output_dir_path, exist_ok=True)
 
             # Need a set files to repeat download for FAILED ones only
-            monitoring_failed_downloads_file = os.path.join(tmp_output_dir_path, "failed_files.txt")
+            monitoring_failed_downloads_file = os.path.abspath(os.path.join(tmp_output_dir_path, "failed_files.txt"))
             monitoring_download_file_stem, monitoring_downloads_file_ext = os.path.splitext(monitoring_failed_downloads_file)
             old_monitoring_failed_downloads_file = f"{monitoring_download_file_stem}_old{monitoring_downloads_file_ext}"
 
@@ -665,7 +665,8 @@ class Gbasf2Process(BatchProcess):
 
                 ds_get_command = shlex.split(f"gb2_ds_get --force {dataset_query_string} "
                                              f"--failed_lfns {monitoring_failed_downloads_file}")
-                print("Downloading dataset with command ", " ".join(ds_get_command))
+                print(f"Downloading dataset into\n  {tmp_output_dir_path}\n  with command\n  ",
+                      " ".join(ds_get_command))
 
             # Any further time is based on the list of files from failed downloads
             else:
@@ -674,7 +675,8 @@ class Gbasf2Process(BatchProcess):
                 ds_get_command = shlex.split(f"gb2_ds_get --force {dataset_query_string} "
                                              f"--input_dslist {old_monitoring_failed_downloads_file} "
                                              f"--failed_lfns {monitoring_failed_downloads_file}")
-                print("Downloading remaining files from dataset with command ", " ".join(ds_get_command))
+                print(f"Downloading remaining files into\n  {tmp_output_dir_path}\n  with command\n  ",
+                      " ".join(ds_get_command))
 
             stdout = run_with_gbasf2(ds_get_command, cwd=tmp_output_dir_path, capture_output=True).stdout
             print(stdout)

--- a/examples/gbasf2/settings.json
+++ b/examples/gbasf2/settings.json
@@ -1,5 +1,4 @@
 {
-    "gbasf2_install_directory": "~/gbasf2KEK",
     "gbasf2_print_status_updates": true,
     "gbasf2_max_retries": 0,
     "gbasf2_cputime": 5,

--- a/tests/batch/test_gbasf2_helper_functions.py
+++ b/tests/batch/test_gbasf2_helper_functions.py
@@ -10,36 +10,51 @@ from collections import namedtuple
 from contextlib import redirect_stderr
 from io import StringIO
 from os.path import join
+from pathlib import Path
 from subprocess import CalledProcessError
 from unittest import mock
+import tempfile
+from typing import Iterable
+import shutil
 
-from b2luigi.batch.processes.gbasf2 import (_get_lfn_upto_reschedule_number, get_proxy_info, get_unique_lfns,
-                                            lfn_follows_gb2v5_convention, query_lpns, setup_dirac_proxy)
+from b2luigi.batch.processes.gbasf2 import (
+    _get_lfn_upto_reschedule_number,
+    get_proxy_info,
+    get_unique_lfns,
+    lfn_follows_gb2v5_convention,
+    query_lpns,
+    setup_dirac_proxy,
+    _move_downloaded_dataset_to_output_dir,
+)
 
 # first test utilities for working with logical file names on the grid
 
 
 class TestLFNFollowsGbasf2V5Convention(unittest.TestCase):
     def test_newstyle_lfn_is_true(self):
-        lfn = 'Upsilon4SBpcandee_00000_job181817516_03.root'
+        lfn = "Upsilon4SBpcandee_00000_job181817516_03.root"
         self.assertTrue(lfn_follows_gb2v5_convention(lfn))
 
     def test_oldstyle_lfn_is_false(self):
-        lfn = 'my_ntuple_0001.root'
+        lfn = "my_ntuple_0001.root"
         self.assertFalse(lfn_follows_gb2v5_convention(lfn))
 
 
 class TestLFNUptoRescheduleNumber(unittest.TestCase):
     def test_strings_equal_camelcase_lfn(self):
-        lfn = 'Upsilon4SBpcandee_00000_job181817516_03.root'
-        self.assertEqual(_get_lfn_upto_reschedule_number(lfn), 'Upsilon4SBpcandee_00000_job181817516')
+        lfn = "Upsilon4SBpcandee_00000_job181817516_03.root"
+        self.assertEqual(
+            _get_lfn_upto_reschedule_number(lfn), "Upsilon4SBpcandee_00000_job181817516"
+        )
 
     def test_strings_equal_snakecase_lfn(self):
-        lfn = 'my_ntuple_name_00000_job181817516_03.root'
-        self.assertEqual(_get_lfn_upto_reschedule_number(lfn), 'my_ntuple_name_00000_job181817516')
+        lfn = "my_ntuple_name_00000_job181817516_03.root"
+        self.assertEqual(
+            _get_lfn_upto_reschedule_number(lfn), "my_ntuple_name_00000_job181817516"
+        )
 
     def test_oldstyle_lfn_raises_error(self):
-        lfn = 'my_ntuple_0001.root'
+        lfn = "my_ntuple_0001.root"
         with self.assertRaises(ValueError):
             _get_lfn_upto_reschedule_number(lfn)
 
@@ -48,57 +63,58 @@ class TestGetUniqueLFNS(unittest.TestCase):
     def setUp(self):
         # list of logical path names on the grid that only differe by the reschedule number (last two digits)
         self.lfns_with_duplicates = [
-            'Upsilon4SBpcandee_00000_job181817516_00.root',
-            'Upsilon4SBpcandee_00001_job181817517_00.root',
-            'Upsilon4SBpcandee_00002_job181817518_00.root',
-            'Upsilon4SBpcandee_00003_job181817519_00.root',
-            'Upsilon4SBpcandee_00004_job181817520_00.root',
-            'Upsilon4SBpcandee_00005_job181817521_00.root',
-            'Upsilon4SBpcandee_00006_job181817522_00.root',
-            'Upsilon4SBpcandee_00007_job181817523_00.root',
-            'Upsilon4SBpcandee_00008_job181817524_00.root',
-            'Upsilon4SBpcandee_00009_job181817525_00.root',
-            'Upsilon4SBpcandee_00010_job181817526_00.root',
-            'Upsilon4SBpcandee_00011_job181817527_00.root',
-            'Upsilon4SBpcandee_00012_job181817528_00.root',
-            'Upsilon4SBpcandee_00012_job181817528_00.root',
-            'Upsilon4SBpcandee_00012_job181817528_02.root',
-            'Upsilon4SBpcandee_00013_job181817529_00.root',
-            'Upsilon4SBpcandee_00014_job181817530_00.root',
-            'Upsilon4SBpcandee_00015_job181817531_00.root',
-            'Upsilon4SBpcandee_00016_job181817532_00.root',
-            'Upsilon4SBpcandee_00017_job181817533_00.root',
-            'Upsilon4SBpcandee_00017_job181817533_01.root',
-            'Upsilon4SBpcandee_00017_job181817533_02.root',
-            'Upsilon4SBpcandee_00018_job181817534_01.root',
-            'Upsilon4SBpcandee_00019_job181817535_00.root',
+            "Upsilon4SBpcandee_00000_job181817516_00.root",
+            "Upsilon4SBpcandee_00001_job181817517_00.root",
+            "Upsilon4SBpcandee_00002_job181817518_00.root",
+            "Upsilon4SBpcandee_00003_job181817519_00.root",
+            "Upsilon4SBpcandee_00004_job181817520_00.root",
+            "Upsilon4SBpcandee_00005_job181817521_00.root",
+            "Upsilon4SBpcandee_00006_job181817522_00.root",
+            "Upsilon4SBpcandee_00007_job181817523_00.root",
+            "Upsilon4SBpcandee_00008_job181817524_00.root",
+            "Upsilon4SBpcandee_00009_job181817525_00.root",
+            "Upsilon4SBpcandee_00010_job181817526_00.root",
+            "Upsilon4SBpcandee_00011_job181817527_00.root",
+            "Upsilon4SBpcandee_00012_job181817528_00.root",
+            "Upsilon4SBpcandee_00012_job181817528_00.root",
+            "Upsilon4SBpcandee_00012_job181817528_02.root",
+            "Upsilon4SBpcandee_00013_job181817529_00.root",
+            "Upsilon4SBpcandee_00014_job181817530_00.root",
+            "Upsilon4SBpcandee_00015_job181817531_00.root",
+            "Upsilon4SBpcandee_00016_job181817532_00.root",
+            "Upsilon4SBpcandee_00017_job181817533_00.root",
+            "Upsilon4SBpcandee_00017_job181817533_01.root",
+            "Upsilon4SBpcandee_00017_job181817533_02.root",
+            "Upsilon4SBpcandee_00018_job181817534_01.root",
+            "Upsilon4SBpcandee_00019_job181817535_00.root",
         ]
         # create same input but with more underscores in initial root file name (snake case)
         # to test whether the string splitting logic is stable in that case
         self.lfns_with_duplicates_snake_case = [
-            lfn.replace("Upsilon4SBpcandee", "u4s_Bp_cand_") for lfn in self.lfns_with_duplicates
+            lfn.replace("Upsilon4SBpcandee", "u4s_Bp_cand_")
+            for lfn in self.lfns_with_duplicates
         ]
         self.unique_lfns = {
-            'Upsilon4SBpcandee_00000_job181817516_00.root',
-            'Upsilon4SBpcandee_00001_job181817517_00.root',
-            'Upsilon4SBpcandee_00002_job181817518_00.root',
-            'Upsilon4SBpcandee_00003_job181817519_00.root',
-            'Upsilon4SBpcandee_00004_job181817520_00.root',
-            'Upsilon4SBpcandee_00005_job181817521_00.root',
-            'Upsilon4SBpcandee_00006_job181817522_00.root',
-            'Upsilon4SBpcandee_00007_job181817523_00.root',
-            'Upsilon4SBpcandee_00008_job181817524_00.root',
-            'Upsilon4SBpcandee_00009_job181817525_00.root',
-            'Upsilon4SBpcandee_00010_job181817526_00.root',
-            'Upsilon4SBpcandee_00011_job181817527_00.root',
-            'Upsilon4SBpcandee_00012_job181817528_02.root',
-            'Upsilon4SBpcandee_00013_job181817529_00.root',
-            'Upsilon4SBpcandee_00014_job181817530_00.root',
-            'Upsilon4SBpcandee_00015_job181817531_00.root',
-            'Upsilon4SBpcandee_00016_job181817532_00.root',
-            'Upsilon4SBpcandee_00017_job181817533_02.root',
-            'Upsilon4SBpcandee_00018_job181817534_01.root',
-            'Upsilon4SBpcandee_00019_job181817535_00.root',
+            "Upsilon4SBpcandee_00000_job181817516_00.root",
+            "Upsilon4SBpcandee_00001_job181817517_00.root",
+            "Upsilon4SBpcandee_00002_job181817518_00.root",
+            "Upsilon4SBpcandee_00003_job181817519_00.root",
+            "Upsilon4SBpcandee_00004_job181817520_00.root",
+            "Upsilon4SBpcandee_00005_job181817521_00.root",
+            "Upsilon4SBpcandee_00006_job181817522_00.root",
+            "Upsilon4SBpcandee_00007_job181817523_00.root",
+            "Upsilon4SBpcandee_00008_job181817524_00.root",
+            "Upsilon4SBpcandee_00009_job181817525_00.root",
+            "Upsilon4SBpcandee_00010_job181817526_00.root",
+            "Upsilon4SBpcandee_00011_job181817527_00.root",
+            "Upsilon4SBpcandee_00012_job181817528_02.root",
+            "Upsilon4SBpcandee_00013_job181817529_00.root",
+            "Upsilon4SBpcandee_00014_job181817530_00.root",
+            "Upsilon4SBpcandee_00015_job181817531_00.root",
+            "Upsilon4SBpcandee_00016_job181817532_00.root",
+            "Upsilon4SBpcandee_00017_job181817533_02.root",
+            "Upsilon4SBpcandee_00018_job181817534_01.root",
+            "Upsilon4SBpcandee_00019_job181817535_00.root",
         }
         self.unique_lfns_snake_case = {
             lfn.replace("Upsilon4SBpcandee", "u4s_Bp_cand_") for lfn in self.unique_lfns
@@ -121,7 +137,9 @@ class TestGetUniqueLFNS(unittest.TestCase):
         self.assertSetEqual(unique_lfns, self.unique_lfns)
 
     def test_sets_equal_underscore_in_file_name_input_as_set(self):
-        unique_lfns_snake_case = get_unique_lfns(set(self.lfns_with_duplicates_snake_case))
+        unique_lfns_snake_case = get_unique_lfns(
+            set(self.lfns_with_duplicates_snake_case)
+        )
         self.assertSetEqual(unique_lfns_snake_case, self.unique_lfns_snake_case)
 
 
@@ -136,14 +154,14 @@ class TestSetupDiracProxy(unittest.TestCase):
     success_msg = "Succeed with return value:\n0"
     error_msg = "Error: Operation not permitted ( 1 : )"
     wrong_pw_msg = (
-        "Generating proxy..."
-        "Enter Certificate password:"
-        "Bad passphrase"
+        "Generating proxy..." "Enter Certificate password:" "Bad passphrase"
     ) + f"\n{error_msg}"
 
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
-    def test_dont_setup_when_proxy_alive(self, mock_get_proxy_info, mock_run_with_gbasf2):
+    def test_dont_setup_when_proxy_alive(
+        self, mock_get_proxy_info, mock_run_with_gbasf2
+    ):
         mock_get_proxy_info.return_value = {"secondsLeft": 999}
         setup_dirac_proxy()
         # check that gb2_proxy_init was never called via subprocess
@@ -160,9 +178,13 @@ class TestSetupDiracProxy(unittest.TestCase):
 
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
-    def test_setup_proxy_when_no_proxy_info(self, mock_get_proxy_info, mock_run_with_gbasf2):
+    def test_setup_proxy_when_no_proxy_info(
+        self, mock_get_proxy_info, mock_run_with_gbasf2
+    ):
         # pretend proxy is not initalized yet, then get_proxy_info raises CalledProcessError
-        mock_get_proxy_info.side_effect = CalledProcessError(1, ["gb2_proxy_info", "-g", "belle"])
+        mock_get_proxy_info.side_effect = CalledProcessError(
+            1, ["gb2_proxy_info", "-g", "belle"]
+        )
         mock_run_with_gbasf2.return_value = MockProcess(self.success_msg, "")
         setup_dirac_proxy()
         self.assertEqual(mock_run_with_gbasf2.call_count, 1)
@@ -177,7 +199,7 @@ class TestSetupDiracProxy(unittest.TestCase):
         return_processes = [
             MockProcess(self.wrong_pw_msg, ""),
             MockProcess("", self.wrong_pw_msg),
-            MockProcess(self.success_msg, "")
+            MockProcess(self.success_msg, ""),
         ]
         mock_run_with_gbasf2.side_effect = return_processes
 
@@ -186,13 +208,18 @@ class TestSetupDiracProxy(unittest.TestCase):
             setup_dirac_proxy()
         self.assertListEqual(
             stderr.getvalue().splitlines(),
-            ['Wrong certificate password, please try again.', 'Wrong certificate password, please try again.'],
+            [
+                "Wrong certificate password, please try again.",
+                "Wrong certificate password, please try again.",
+            ],
         )
         self.assertEqual(mock_run_with_gbasf2.call_count, len(return_processes))
 
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
-    def test_raises_error_when_errormsg_in_stdout(self, mock_get_proxy_info, mock_run_with_gbasf2):
+    def test_raises_error_when_errormsg_in_stdout(
+        self, mock_get_proxy_info, mock_run_with_gbasf2
+    ):
         mock_get_proxy_info.return_value = {"secondsLeft": 0}
         # check that gb2_proxy_init was never called via subprocess
         mock_run_with_gbasf2.return_value = MockProcess(self.error_msg, "")
@@ -200,15 +227,18 @@ class TestSetupDiracProxy(unittest.TestCase):
             setup_dirac_proxy()
 
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
-    def test_get_proxy_info_doesnt_suppress_called_process_error(self, mock_run_with_gbasf2):
-        mock_run_with_gbasf2.side_effect = CalledProcessError(1, ["gb2_proxy_info", "-g", "belle"])
+    def test_get_proxy_info_doesnt_suppress_called_process_error(
+        self, mock_run_with_gbasf2
+    ):
+        mock_run_with_gbasf2.side_effect = CalledProcessError(
+            1, ["gb2_proxy_info", "-g", "belle"]
+        )
         with self.assertRaises(CalledProcessError):
             get_proxy_info()
         self.assertEqual(mock_run_with_gbasf2.call_count, 1)
 
 
 class TestQueryLPNs(unittest.TestCase):
-
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     def test_single_file_list(self, mock_run_with_gbasf2):
         output = (
@@ -219,8 +249,12 @@ class TestQueryLPNs(unittest.TestCase):
         lpns = query_lpns("mock query", "mock user")
         self.assertListEqual(
             lpns,
-            [join("/belle/Data/release-05-01-24/DB00001454/SkimP12x1/prod00019339/e0008/4S/r02547/",
-                  "hadron/11180500/udst/sub00/udst_000001_prod00019339_task72546000001.root")]
+            [
+                join(
+                    "/belle/Data/release-05-01-24/DB00001454/SkimP12x1/prod00019339/e0008/4S/r02547/",
+                    "hadron/11180500/udst/sub00/udst_000001_prod00019339_task72546000001.root",
+                )
+            ],
         )
 
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
@@ -229,3 +263,62 @@ class TestQueryLPNs(unittest.TestCase):
         mock_run_with_gbasf2.return_value = MockProcess(wrong_type_output, "")
         with self.assertRaises(TypeError):
             query_lpns("mock query", "mock user")
+
+
+class TestMoveDownloadedDatasetToOutputDir(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def _create_mock_project_download_dir(
+        self, project_name: str, root_files_per_sub: Iterable[int] = (0,)
+    ) -> Path:
+        downloaded_project_path = self.test_dir / project_name
+        downloaded_project_path.mkdir(exist_ok=True)
+        for sub_idx, n_files in enumerate(root_files_per_sub):
+            assert sub_idx < 100, "There  can't be more than 100 subs"
+            # create sub<xy>-directory
+            sub_dir = downloaded_project_path / f"sub{sub_idx:02d}"
+            sub_dir.mkdir(exist_ok=False)
+            # create dummy root files in sub<xy> directory:
+            for file_idx in range(n_files):
+                root_fpath = sub_dir / f"sub{sub_idx:02d}_file{file_idx:04d}.root"
+                root_fpath.touch(exist_ok=False)
+        return downloaded_project_path
+
+    def test_moving_of_multiple_subs(self):
+        root_files_per_sub = [10, 10, 10]
+        project_path = self._create_mock_project_download_dir(
+            project_name="multiple_subs", root_files_per_sub=root_files_per_sub
+        )
+        project_root_fnames = [
+            root_fpath.name for root_fpath in project_path.glob("sub*/*.root")
+        ]
+
+        output_path = self.test_dir / "multiple_subs_output.root"
+        _move_downloaded_dataset_to_output_dir(
+            project_path.as_posix(), output_path.as_posix()
+        )
+        output_root_fnames = [
+            root_fpath.name for root_fpath in output_path.glob("*.root")
+        ]
+
+        # check that all root files have been moved to output directory
+        self.assertCountEqual(output_root_fnames, project_root_fnames)
+        # Test the number of output files is what we expect
+        self.assertEqual(len(output_root_fnames), sum(root_files_per_sub))
+        # check that input directory is empty after move
+        self.assertListEqual(list(project_path.glob("sub*/*.root")), [])
+
+    def test_error_when_a_sub_is_empty(self):
+        root_files_per_sub = [10, 0, 10]
+        project_path = self._create_mock_project_download_dir(
+            project_name="empty_subs", root_files_per_sub=root_files_per_sub
+        )
+        output_path = self.test_dir / "empty_subs_output.root"
+        with self.assertRaises(RuntimeError):
+            _move_downloaded_dataset_to_output_dir(
+                project_path.as_posix(), output_path.as_posix()
+            )


### PR DESCRIPTION
For datasets with multiple subs, when moving the contents of the temporary project download directory to the final ouptut dir, previously, there was an error which led to the file structure:

    <result_dir>/B.root/job_name*B.root  # sub00 contents
    <result_dir>/B.root/sub01/job_name*B.root
    <result_dir>/B.root/sub02/job_name*B.root

This commit should fix this back to

    <result_dir>/B.root/job_name*B.root  # contents of all subs

Further, since this moving function turns out to aggregate many lines of code, I moved it into an own helper function, which can be independently tested.

Draft so that I can link to it, but I haven't finished yet writing unit tests.
- [x] Add unit-tests for multi-sub directory structures with dummy root files
- [x] Run a job on the  grid with one input file to check that the single-sub case still works.

Resolves #147 