### PR TITLE
Add some minor improvements to documentation

### DIFF
--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -15,7 +15,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
     .. code-block:: bash
 
-        pip3 uninstall b2luigi
+        python -m pip uninstall b2luigi
 
 2.  Clone the repository from github
 
@@ -28,7 +28,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
     .. code-block:: bash
 
-        pip3 [ --user ] install flit
+        python -m pip [ --user ] install flit
 
     You can now install ``b2luigi`` from the cloned git repository in development mode:
 
@@ -42,7 +42,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
     .. code-block:: bash
 
-        pip3 [ --user ] install pre-commit
+        python -m pip [ --user ] install pre-commit
         pre-commit install  # install the pre-commit hooks
         pre-commit  # run pre-commit manually, checks all staged ("added") changes
 
@@ -65,7 +65,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
     .. code-block:: bash
 
-        pip3 [ --user ] install sphinx sphinx-autobuild
+        python -m pip [ --user ] install sphinx sphinx-autobuild
 
     And starting the automatic build process in the projects root folder
 

--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -56,7 +56,7 @@ You want to help developing ``b2luigi``? Great! Here are some first steps to hel
 
     .. code-block:: bash
 
-        python3 -m unittest
+        python -m unittest
 
    in the root of ``b2luigi`` repository. If you add some functionality, try to add some tests for it.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
 b2luigi
 =======
 
-``b2luigi`` - bringing batch 2 luigi!
+``b2luigi`` — bringing batch 2 luigi!
 
 
-``b2luigi`` is a helper package for  ``luigi`` for scheduling large luigi workflows on a batch system.
+``b2luigi`` is a helper package for ``luigi`` for scheduling large luigi workflows on a batch system.
 It is as simple as
 
 .. code-block:: python

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -37,9 +37,6 @@ Now you can go on with the :ref:`quick-start-label`.
 b2luigi and Belle II
 ---------------------
 
-Starting from release 04-00-00, `b2luigi` is already included in the externals.
-Follow this guid, if you want to update to the newest version nevertheless.
-
 1.  Setup your local environment. You can use a local environment (installed on your machine) or a release on cvmfs.
     For example, run:
 

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -68,7 +68,9 @@ b2luigi and Belle II
 
 
 .. attention::
-    The examples in this documentation are all shown with calling ``python``, but basf2 users need to use ``python3``
-    instead.
+    The examples in this documentation are all shown with calling ``python``,
+    assuming this refers to the *Python 3* executable of their (virtual) environment.
+    In some systems and e.g. basf2 environments, ``python`` refers to Python 2
+    (not supported by b2luigi). Then, ``python3`` should be used instead.
 
 Please also have a look into the :ref:`basf2-example-label`.

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -67,7 +67,8 @@ b2luigi and Belle II
         python -m pip install --user b2luigi --upgrade
 
 
-The examples in this documentation are all shown with calling ``python``, but basf2 users need to use ``python3``
-instead.
+.. attention::
+    The examples in this documentation are all shown with calling ``python``, but basf2 users need to use ``python3``
+    instead.
 
 Please also have a look into the :ref:`basf2-example-label`.

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -18,7 +18,7 @@ This installation description is for the general user. If you are using the Bell
 
     .. code-block:: bash
 
-        pip3 install b2luigi
+        python -m pip install b2luigi
 
 
     b.  If this fails because you do not have write access to where your virtual environment lives, you can also install
@@ -26,7 +26,7 @@ This installation description is for the general user. If you are using the Bell
 
     .. code-block:: bash
 
-        pip3 install --user b2luigi
+        python -m pip install --user b2luigi
 
     This will automatically also install `luigi` into your current environment.
     Please make sure to always setup your environment correctly before using `b2luigi`.
@@ -57,14 +57,14 @@ b2luigi and Belle II
 
     .. code-block:: bash
 
-        pip3 install b2luigi -U
+        python -m pip install b2luigi --upgrade
 
 
     b.  If you are using an installation from cvmfs, you need to add the ``user`` flag.
 
     .. code-block:: bash
 
-        pip3 install --user b2luigi -U
+        python -m pip install --user b2luigi --upgrade
 
 
 The examples in this documentation are all shown with calling ``python``, but basf2 users need to use ``python3``

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -159,7 +159,7 @@ Later, we will build the average of those numbers.
 
         .. code-block:: bash
 
-            python3 simple-example.py --show-output
+            python simple-example.py --show-output
 
         More on file systems is described in :ref:`batch-label`, which is also mostly
         true for non-batch calculations.


### PR DESCRIPTION
- b2luigi is not in basf2 externals anymore, so remove that mention from the docs

- There was a hint that `python` instead of `python3` is used in the docs, but that hint was not very visible and despite it `python3` was still used in some places. Make that hint more visible and be consistent with `python` use

- Use `python -m pip` over `python3`

- Minor formatting improvements