### PR TITLE
Add 3 retries for getting HTCondor job status via retry2 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+* HTCondor: Do up to 3 retries for getting job status with `condor_q`
+
 ## [0.7.4] - 2021-11-03
 
 ### Added

--- a/b2luigi/batch/cache.py
+++ b/b2luigi/batch/cache.py
@@ -1,6 +1,5 @@
-from cachetools import TTLCache
-
 import abc
+from cachetools import TTLCache
 
 
 class BatchJobStatusCache(abc.ABC, TTLCache):
@@ -17,7 +16,7 @@ class BatchJobStatusCache(abc.ABC, TTLCache):
     which are not started by this b2luigi instance) does not matter.
     """
     def __init__(self):
-        super(BatchJobStatusCache, self).__init__(maxsize=1000, ttl=20)
+        super().__init__(maxsize=1000, ttl=20)
 
     @abc.abstractmethod
     def _ask_for_job_status(self, job_id=None):

--- a/b2luigi/batch/processes/htcondor.py
+++ b/b2luigi/batch/processes/htcondor.py
@@ -4,6 +4,8 @@ import re
 import subprocess
 import enum
 
+from retry import retry
+
 from b2luigi.core.settings import get_setting
 from b2luigi.batch.processes import BatchProcess, JobStatus
 from b2luigi.batch.cache import BatchJobStatusCache
@@ -13,6 +15,7 @@ from b2luigi.core.executable import create_executable_wrapper
 
 class HTCondorJobStatusCache(BatchJobStatusCache):
 
+    @retry(subprocess.CalledProcessError, tries=3, delay=2, backoff=3)  # retry after 2,6,18 seconds
     def _ask_for_job_status(self, job_id: int = None):
         """
         With HTCondor, you can check the progress of your jobs using the `condor_q` command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,4 @@ author-email = "nils.braun@kit.edu"
 home-page = "https://github.com/nils-braun/b2luigi"
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 
-requires=['luigi>=3.0.2', 'parse>=1.8.4', 'GitPython>=2.1.11', "colorama>=0.3.9", "cachetools>=2.1.0", "jinja2"]
+requires=['luigi>=3.0.2', 'parse>=1.8.4', 'GitPython>=2.1.11', "colorama>=0.3.9", "cachetools>=2.1.0", "jinja2", "retry2>=0.9.3"]

--- a/tests/batch/test_htcondor_processs.py
+++ b/tests/batch/test_htcondor_processs.py
@@ -5,21 +5,24 @@ Utilities that require a running gbasf2 or Dirac environment will not net
 tested in this test case, only the functions that can be run independently.
 """
 
-from b2luigi.batch.processes.htcondor import HTCondorProcess
+import json
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+import b2luigi
+from b2luigi.batch.processes.htcondor import HTCondorJobStatusCache, HTCondorProcess
 
 from ..helpers import B2LuigiTestCase
 from .batch_task_1 import MyTask
-from unittest.mock import Mock
-import os
-import b2luigi
 
 
 class TestHTCondorCreateSubmitFile(B2LuigiTestCase):
-
     def _get_htcondor_submit_file_string(self, task):
         # the _create_htcondor_submit_file is a method of the ``HTCondorProcess`` class, but it only uses its
         # class to obtain ``self.task``, to it's sufficient to provide a mock class for ``self``, `
-        htcondor_mock_process = Mock()
+        htcondor_mock_process = mock.Mock()
         task.get_task_file_dir = lambda: self.test_dir
         htcondor_mock_process.task = task
         #  create submit file
@@ -74,3 +77,60 @@ class TestHTCondorCreateSubmitFile(B2LuigiTestCase):
         b2luigi.clear_setting("htcondor_settings")
         self.assertNotIn("JobBatchName = job_name_global", submit_file_lines)
         self.assertIn("JobBatchName = job_name_htcondor", submit_file_lines)
+
+
+class TestHTCondorJobStatusCache(unittest.TestCase):
+    def setUp(self):
+        mock_status_dicts = [
+            {
+                "JobStatus": 4,  # completed
+                "ExitCode": 0,  # success
+                "ClusterId": 42,
+            },
+            {
+                "JobStatus": 2,  # running
+                "ClusterId": 43,
+            },
+            {
+                "JobStatus": 999,  # failed
+                "ClusterId": 44,
+            },
+        ]
+        self.mock_status_json = json.dumps(mock_status_dicts).encode()
+
+        self.htcondor_job_status_cache = HTCondorJobStatusCache()
+
+    @mock.patch("subprocess.check_output")
+    def test_ask_for_job_status_does_2_retries(self, mock_check_output):
+        """Test the ``_ask_for_job_status`` recovers after two condor_q failures."""
+
+        # make check_output fail 2 times before  return status dict
+        n_fail = 2
+        mock_check_output.side_effect = n_fail * [
+            subprocess.CalledProcessError(1, ["mock", "command"])
+        ] + [self.mock_status_json]
+        self.htcondor_job_status_cache._ask_for_job_status()
+        self.assertEqual(mock_check_output.call_count, 3)
+
+    @mock.patch("subprocess.check_output")
+    def test_ask_for_job_status_no_retries_on_success(self, mock_check_output):
+        """Test the ``_ask_for_job_status`` is only called once (no retries) when everything works."""
+
+        # make check_output fail 2 times before  return status dict
+        mock_check_output.return_value = self.mock_status_json
+        self.htcondor_job_status_cache._ask_for_job_status()
+        self.assertEqual(mock_check_output.call_count, 1)
+
+    @mock.patch("subprocess.check_output")
+    def test_ask_for_job_status_fails_after_4_condor_q_failures(
+        self, mock_check_output
+    ):
+        """Test the ``_ask_for_job_status`` does not do more than 3 retries"""
+
+        # make check_output fail 2 times before  return status dict
+        n_fail = 4
+        mock_check_output.side_effect = n_fail * [
+            subprocess.CalledProcessError(1, ["mock", "command"])
+        ] + [self.mock_status_json]
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.htcondor_job_status_cache._ask_for_job_status()


### PR DESCRIPTION
Hopefully solves #116. Replaces PR #134 by using the retry package instead of implementing the retry code ourselves, with the downside of more dependencies.

- [x] TODO: add unit test to check that retries happen and that after it continues normally