### PR TITLE
gbasf2 fix: Ensure proxy is initialized before getting user

### DIFF
--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -944,6 +944,7 @@ def get_proxy_info():
     return json.loads(proc.stdout)
 
 
+@lru_cache(maxsize=None)
 def get_dirac_user():
     """Get dirac user name."""
     # ensure proxy is initialized, because get_proxy_info can't do it, otherwise

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -934,7 +934,8 @@ def get_proxy_info():
         "gbasf2_utils/gbasf2_proxy_info.py"
     )
 
-    # Setting ``initalize_proxy=False`` is vital here, otherwise we get an infinite loop
+    # Setting ``ensure_proxy_initialized=False`` is vital here, otherwise we get
+    # an infinite loop because run_with_gbasf2 will then check for the proxy info
     proc = run_with_gbasf2(
         [proxy_info_script_path],
         capture_output=True,
@@ -945,6 +946,9 @@ def get_proxy_info():
 
 def get_dirac_user():
     """Get dirac user name."""
+    # ensure proxy is initialized, because get_proxy_info can't do it, otherwise
+    # it causes an infinite loop
+    setup_dirac_proxy()
     try:
         return get_proxy_info()["username"]
     except KeyError as err:

--- a/tests/batch/test_gbasf2_helper_functions.py
+++ b/tests/batch/test_gbasf2_helper_functions.py
@@ -25,6 +25,7 @@ from b2luigi.batch.processes.gbasf2 import (
     query_lpns,
     setup_dirac_proxy,
     _move_downloaded_dataset_to_output_dir,
+    get_dirac_user,
 )
 
 # first test utilities for working with logical file names on the grid
@@ -322,3 +323,20 @@ class TestMoveDownloadedDatasetToOutputDir(unittest.TestCase):
             _move_downloaded_dataset_to_output_dir(
                 project_path.as_posix(), output_path.as_posix()
             )
+
+
+class TestGetDiracUser(unittest.TestCase):
+
+    @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
+    @mock.patch("b2luigi.batch.processes.gbasf2.setup_dirac_proxy")
+    def test_get_dirac_user_gets_user(self, _, mock_get_proxy_info):
+        mock_get_proxy_info.return_value = {
+            "username": "testuser"}
+        self.assertEqual(get_dirac_user(), "testuser")
+
+    @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
+    @mock.patch("b2luigi.batch.processes.gbasf2.setup_dirac_proxy")
+    def test_get_dirac_user_ensures_proxy_initialized(self, mock_setup_dirac_proxy, mock_get_proxy_info):
+        mock_get_proxy_info.return_value = {"username": "testuser"}
+        get_dirac_user()
+        self.assertEqual(mock_setup_dirac_proxy.call_count, 1)


### PR DESCRIPTION
A minor enhancement is that I added caching to the function because I saw it takes some seconds on the command line, which we could save.