### PR TITLE
Use setting for gbasf2 setup file instead of install directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ Older entries have been generated from github releases.
 New entries aim to adhere to the format proposed by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* **gbasf2:** New setting `gbasf2_setup_path` which can be used to customize the path to the gbasf2 setup file directly (default: `"/cvmfs/belle.kek.jp/grid/gbasf2/pro/tools/setup.sh"`). It is a more flexible replacement for the `gbasf2_install_directory` setting, which will be removed in the future, since we can't predict potential name and path changes of the setup script between gbasf2 releases. @meliache #162
+
 ## [0.10.0] - 2023-04-03
 
-## Changed
+### Changed
 
 - For local basf2 versions, change how hash for `basf2_release` Parameter is calculated. Now use basf2 functionality to get the version, to be consistent with the output of `basf2 --version`. The new hash encodes both the local and central basf2 release, the basf2 function [`getCommitID`](https://github.com/belle2/basf2/blob/1c972b2c89ef11f38ee2f5ea8eb562dde0637155/framework/io/include/RootIOUtilities.h#L77-L84). When basf2 is not set up, print warning before returning `"not_set"`. Thanks to @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193).
 
@@ -18,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Refactor the basf2 related examples to use more idiomatic, modern basf2 code, e.g. using `basf2.Path()` instead of `basf2.create_path()`. . Also by @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193)
 
-## Fixed
+### Fixed
 
 - Fix example `SimulationTask` task in `basf2_chain_example.py`, which probably wasn't working as it was missing the Geometry module. Also by @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193)
 

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -1177,21 +1177,15 @@ def get_gbasf2_env(gbasf2_setup_path):
     # complete bash command to set up the gbasf2 environment
     # piping output to /dev/null, because we want that our final script only prints the ``env`` output
     gbasf2_setup_command_str = f"source {gbasf2_setup_path} > /dev/null"
+    home = os.environ["HOME"]  # I want to run gbasf2 setup from empty env, but HOME is required
     # command to execute the gbasf2 setup command in a fresh shell and output the produced environment
     echo_gbasf2_env_command = shlex.split(
-        f"env -i bash -c '{gbasf2_setup_command_str} > /dev/null && env'"
+        f"env -i HOME='{home}' bash -c '{gbasf2_setup_command_str} > /dev/null && env'"
     )
     gbasf2_env_string = subprocess.run(
         echo_gbasf2_env_command, check=True, stdout=subprocess.PIPE, encoding="utf-8"
     ).stdout
     gbasf2_env = dict(line.split("=", 1) for line in gbasf2_env_string.splitlines())
-    # The gbasf2 setup script on sets HOME to /ext/home/ueda if it's unset,
-    # which later causes problems in the gb2_proxy_init subprocess. Therefore,
-    # reset it to the caller's HOME.
-    try:
-        gbasf2_env["HOME"] = os.environ["HOME"]
-    except KeyError:
-        pass
     return gbasf2_env
 
 


### PR DESCRIPTION
Usage of `gbasf2_install_directory` will cause a pending deprecation warning,
but it can still be used and then the corresponding path to
the `setup.sh` will be derived.

## Rationale:

b2luigi only needs to know which file to source to get the correct
environment. The location or name of that file withing a gbasf2 install
directory can change between gbasf2 releases. Providing the file path directly
results in more simplicity and flexibility.

## Additional enhancement:

In addition, the setting is now only obtained in the `Gbasf2Process` class and
not in the free helper functions, which now get the value via function
arguments. With this, the setting can be provided via a Task class attribute and
the value from the Task attribute will be used everywhere as expected.
This resulted in much more boiler plate code, but also it made my helper
function much more usable as library function without b2luigi settings.