### PR TITLE
Fix the proxy creation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+* **gbasf2**: Fix `ioctl` error in `gb2_proxy_init` by reading in password via `b2luigi` and then supplying password to that command directly, instead of letting `gb2_proxy_init` handle the password prompt. #172 @bilokin
+
 ### Added
 * [#166](https://github.com/nils-braun/b2luigi/pull/166): add automatic need-changelog PR labeller as github workflow
 

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -972,8 +972,10 @@ def setup_dirac_proxy():
 
     while True:
         pwd = getpass("Certificate password: ")
-        proc = run_with_gbasf2(proxy_init_cmd, input=pwd, ensure_proxy_initialized=False, capture_output=True, check=True)
-        del pwd
+        try:
+            proc = run_with_gbasf2(proxy_init_cmd, input=pwd, ensure_proxy_initialized=False, capture_output=True, check=True)
+        finally:
+            del pwd
         # Check if there were any errors, since gb2_proxy_init often still exits without errorcode and sends messages to stdout
         out, err = proc.stdout, proc.stderr
         all_output = out + err  # gb2_proxy_init errors are usually in stdout, but for future-proofing also check stderr

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -971,7 +971,7 @@ def setup_dirac_proxy():
     proxy_init_cmd = shlex.split(f"gb2_proxy_init -g belle -v {hours}:00 --pwstdin")
 
     while True:
-        pwd = getpass('Certificate password: ')
+        pwd = getpass("Certificate password: ")
         proc = run_with_gbasf2(proxy_init_cmd, input=pwd, ensure_proxy_initialized=False, capture_output=True, check=True)
         del pwd
         # Check if there were any errors, since gb2_proxy_init often still exits without errorcode and sends messages to stdout

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -971,7 +971,7 @@ def setup_dirac_proxy():
     proxy_init_cmd = shlex.split(f"gb2_proxy_init -g belle -v {hours}:00 --pwstdin")
 
     while True:
-        pwd = getpass('Certificate password:')
+        pwd = getpass('Certificate password: ')
         proc = run_with_gbasf2(proxy_init_cmd, input=pwd, ensure_proxy_initialized=False, capture_output=True, check=True)
         del pwd
         # Check if there were any errors, since gb2_proxy_init often still exits without errorcode and sends messages to stdout

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -15,6 +15,7 @@ from functools import lru_cache
 from glob import glob
 from itertools import groupby
 from typing import Iterable, List, Optional, Set
+from getpass import getpass
 
 from b2luigi.basf2_helper.utils import get_basf2_git_hash
 from b2luigi.batch.processes import BatchProcess, JobStatus
@@ -967,11 +968,12 @@ def setup_dirac_proxy():
     if not isinstance(lifetime, int) or lifetime <= 0:
         warnings.warn("Setting 'gbasf2_proxy_lifetime' should be a positive integer.", RuntimeWarning)
     hours = int(lifetime)
-    proxy_init_cmd = shlex.split(f"gb2_proxy_init -g belle -v {hours}:00")
+    proxy_init_cmd = shlex.split(f"gb2_proxy_init -g belle -v {hours}:00 --pwstdin")
 
     while True:
-        proc = run_with_gbasf2(proxy_init_cmd, ensure_proxy_initialized=False, capture_output=True, check=True)
-
+        pwd = getpass('Certificate password:')
+        proc = run_with_gbasf2(proxy_init_cmd, input=pwd, ensure_proxy_initialized=False, capture_output=True, check=True)
+        del pwd
         # Check if there were any errors, since gb2_proxy_init often still exits without errorcode and sends messages to stdout
         out, err = proc.stdout, proc.stderr
         all_output = out + err  # gb2_proxy_init errors are usually in stdout, but for future-proofing also check stderr

--- a/tests/batch/test_gbasf2_helper_functions.py
+++ b/tests/batch/test_gbasf2_helper_functions.py
@@ -157,30 +157,34 @@ class TestSetupDiracProxy(unittest.TestCase):
     wrong_pw_msg = (
         "Generating proxy..." "Enter Certificate password:" "Bad passphrase"
     ) + f"\n{error_msg}"
-
+    @mock.patch("b2luigi.batch.processes.gbasf2.getpass")
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
     def test_dont_setup_when_proxy_alive(
-        self, mock_get_proxy_info, mock_run_with_gbasf2
+        self, mock_get_proxy_info, mock_run_with_gbasf2, mock_getpass
     ):
         mock_get_proxy_info.return_value = {"secondsLeft": 999}
         setup_dirac_proxy()
         # check that gb2_proxy_init was never called via subprocess
+        mock_getpass.return_value = 'pwd'
         self.assertEqual(mock_run_with_gbasf2.call_count, 0)
-
+    
+    @mock.patch("b2luigi.batch.processes.gbasf2.getpass")
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
-    def test_setup_proxy_on_0_seconds(self, mock_get_proxy_info, mock_run_with_gbasf2):
+    def test_setup_proxy_on_0_seconds(self, mock_get_proxy_info, mock_run_with_gbasf2, mock_getpass):
         # force setting up of new proxy
         mock_get_proxy_info.return_value = {"secondsLeft": 0}
+        mock_getpass.return_value = 'pwd'
         mock_run_with_gbasf2.return_value = MockProcess(self.success_msg, "")
         setup_dirac_proxy()
         self.assertEqual(mock_run_with_gbasf2.call_count, 1)
 
+    @mock.patch("b2luigi.batch.processes.gbasf2.getpass")
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
     def test_setup_proxy_when_no_proxy_info(
-        self, mock_get_proxy_info, mock_run_with_gbasf2
+        self, mock_get_proxy_info, mock_run_with_gbasf2, mock_getpass
     ):
         # pretend proxy is not initalized yet, then get_proxy_info raises CalledProcessError
         mock_get_proxy_info.side_effect = CalledProcessError(
@@ -190,9 +194,10 @@ class TestSetupDiracProxy(unittest.TestCase):
         setup_dirac_proxy()
         self.assertEqual(mock_run_with_gbasf2.call_count, 1)
 
+    @mock.patch("b2luigi.batch.processes.gbasf2.getpass")
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
-    def test_retry_on_wrong_password(self, mock_get_proxy_info, mock_run_with_gbasf2):
+    def test_retry_on_wrong_password(self, mock_get_proxy_info, mock_run_with_gbasf2, mock_getpass):
         # force setting up of new proxy
         mock_get_proxy_info.return_value = {"secondsLeft": 0}
 
@@ -216,10 +221,11 @@ class TestSetupDiracProxy(unittest.TestCase):
         )
         self.assertEqual(mock_run_with_gbasf2.call_count, len(return_processes))
 
+    @mock.patch("b2luigi.batch.processes.gbasf2.getpass")
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
     def test_raises_error_when_errormsg_in_stdout(
-        self, mock_get_proxy_info, mock_run_with_gbasf2
+        self, mock_get_proxy_info, mock_run_with_gbasf2, mock_getpass
     ):
         mock_get_proxy_info.return_value = {"secondsLeft": 0}
         # check that gb2_proxy_init was never called via subprocess

--- a/tests/batch/test_gbasf2_helper_functions.py
+++ b/tests/batch/test_gbasf2_helper_functions.py
@@ -157,6 +157,7 @@ class TestSetupDiracProxy(unittest.TestCase):
     wrong_pw_msg = (
         "Generating proxy..." "Enter Certificate password:" "Bad passphrase"
     ) + f"\n{error_msg}"
+
     @mock.patch("b2luigi.batch.processes.gbasf2.getpass")
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")
@@ -168,7 +169,7 @@ class TestSetupDiracProxy(unittest.TestCase):
         # check that gb2_proxy_init was never called via subprocess
         mock_getpass.return_value = 'pwd'
         self.assertEqual(mock_run_with_gbasf2.call_count, 0)
-    
+
     @mock.patch("b2luigi.batch.processes.gbasf2.getpass")
     @mock.patch("b2luigi.batch.processes.gbasf2.run_with_gbasf2")
     @mock.patch("b2luigi.batch.processes.gbasf2.get_proxy_info")


### PR DESCRIPTION
Hello @meliache,

here is a method of fixing the proxy creation error in b2luigi's gbasf2 process. 
The changes in `gb2_proxy_init` caused a `ioctl` error in b2luigi, which can be avoided if we switch to `stdin` input mode and provide a certificate password explicitly. 