### PR TITLE
Parametrize DIRAC group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 * [#166](https://github.com/nils-braun/b2luigi/pull/166): add automatic need-changelog PR labeller as github workflow
+* [#175](https://github.com/nils-braun/b2luigi/pull/175): added ``gbasf2_proxy_group`` and ``gbasf2_project_lpn_path`` parameters to switch between gbasf2 groups.
 
 **Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.7.6...main
 

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -664,6 +664,10 @@ class Gbasf2Process(BatchProcess):
             # If the download had been successful and the local files are identical to the list of files on the grid,
             # we move the downloaded dataset to the location specified by ``output_dir_path``.
             tmp_output_dir_path = f"{output_dir_path}.partial"
+            # if custom group is given we need to append the project name
+            group_name = get_setting("gbasf2_proxy_group", default="belle")
+            if group_name != "belle":
+                tmp_output_dir_path += f"/{self.gbasf2_project_name}"
             os.makedirs(tmp_output_dir_path, exist_ok=True)
 
             # Need a set files to repeat download for FAILED ones only

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -150,6 +150,11 @@ class Gbasf2Process(BatchProcess):
           printing of of the job summaries, that is the number of jobs in different states in a gbasf2 project.
         - ``gbasf2_max_retries``: Default to 0. Maximum number of times that each job in the project can be automatically
           rescheduled until the project is declared as failed.
+        - ``gbasf2_proxy_group``: Default to "belle". If provided, the gbasf2 wrapper will work with the custom gbasf2 group,
+          specified in this parameter. No need to specify this parameter in case of usual physics analysis at Belle II.
+          If specified, one has to provide ``gbasf2_project_lpn_path`` parameter.
+        - ``gbasf2_project_lpn_path``: Path to the LPN folder for a specified gbasf2 group.
+          The parameter has no effect unless the ``gbasf2_proxy_group`` is used with non-default value.
         - ``gbasf2_download_dataset``: Defaults to ``True``. Disable this setting if you don't want to download the
           output dataset from the grid on job success. As you can't use the downloaded dataset as an output target for luigi,
           you should then use the provided ``Gbasf2GridProjectTarget``, as shown in the following example:

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -694,6 +694,7 @@ class Gbasf2Process(BatchProcess):
                       " ".join(ds_get_command))
 
             stdout = run_with_gbasf2(ds_get_command, cwd=tmp_output_dir_path, capture_output=True).stdout
+            print(stdout)
             if "No file found" in stdout:
                 raise RuntimeError(f"No output data for gbasf2 project {self.gbasf2_project_name} found.")
 

--- a/b2luigi/batch/processes/gbasf2_utils/gbasf2_job_status.py
+++ b/b2luigi/batch/processes/gbasf2_utils/gbasf2_job_status.py
@@ -21,7 +21,7 @@ from BelleDIRAC.Client.helpers.auth import userCreds
 
 
 @userCreds
-def get_job_status_dict(project_name, user_name):
+def get_job_status_dict(project_name, user_name, group_name):
     """
     If successful, returns a dictionary for all jobs in the project with a structure like the following,
     which I have taken and adapted from an example output::
@@ -43,7 +43,7 @@ def get_job_status_dict(project_name, user_name):
     """
     if user_name is None:
         user_name = os.getenv("BELLE2_USER")
-    login = [user_name, 'belle']
+    login = [user_name, group_name]
     newer_than = '1970-01-01'
     projects = [project_name]
     info_collector = InformationCollector()
@@ -61,6 +61,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--project', type=str, required=True, help="gbasf2 project name")
     parser.add_argument('-u', '--user', type=str, default=None, help="grid username")
+    parser.add_argument('-g', '--group', type=str, default="belle", help="gbasf2 group name")
     args = parser.parse_args()
-    job_status_dict = get_job_status_dict(args.project, args.user)
+    job_status_dict = get_job_status_dict(args.project, args.user, args.group)
     print(json.dumps(job_status_dict))


### PR DESCRIPTION
Hi @meliache, 

recently, the group policy in gbasf2 was diversified, so the users can now submit the jobs from different DIRAC groups, which have different queue priorities. 
And since there was created a group `belle_systematics`  we would like to add the corresponding functionality to the b2luigi, which is extremely useful for the systematics framework.
To submit a project from a group other than `belle`, one has to do the following:
* Create proxy with the custom group
* Add a custom path to the `gbasf2` command via `--output_path`
* Project download should be done with the same custom DIRAC group
* The project name should be explicitly appended to the temporary  download path, because it is not added by default for a custom group

In this PR I added two optional b2luigi parameters, `gbasf2_proxy_group` and  `gbasf2_project_lpn_path`. 
The latter one is required if the first one is supplied. 

