### PR TITLE
Only build the graph on the batch_worker for non complete tasks.

### DIFF
--- a/b2luigi/cli/runner.py
+++ b/b2luigi/cli/runner.py
@@ -13,7 +13,7 @@ from b2luigi.core.utils import create_output_dirs
 def run_as_batch_worker(task_list, cli_args, kwargs):
     found_task = False
     for root_task in task_list:
-        for task in task_iterator(root_task):
+        for task in task_iterator(root_task, only_non_complete=True):
             if task.task_id != cli_args.task_id:
                 continue
 


### PR DESCRIPTION
I had an issue where the batch worker seemed to get stuck in infinite loops of task requirements (at least I saw it loop over 1+ million tasks before killing the jobs. This is quite strange as such loops are not present within the pipeline and the actual process call is able to build the graph without issue.

While I haven't fully solved the issue yet, I found setting the batch worker to not check dependents of completed tasks sped up the task processing and at least for now avoided the above issue. I'm still investigating my original issue but this change might be more broadly beneficial.