### PR TITLE
stop the task_iterator from re-traversing sections of the graph it has already seen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Older entries have been generated from github releases.
 New entries aim to adhere to the format proposed by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleases
+
+### Added
+
+- `task_iterator` now returns a unique list of tasks. The task graph is a DAG which is traversed through recursion in `task_iterator` like a tree. If multiple tasks had the same task as a requirement (i.e. multiple nodes share a child), it was returned multiple times in the task iterator. This results in performance improvements when checking the requirements. [#186](https://github.com/nils-braun/b2luigi/pull/186). Thanks [@MarcelHoh](https://github.com/MarcelHoh) for the initial PR.
+
+**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.8.2...main
+
 ## [0.8.2] - 2023-01-13
 
 ### Fixed

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -147,7 +147,7 @@ def task_iterator(task, only_non_complete=False, already_seen_tasks = set()):
                 continue
             already_seen_tasks.add(dep.task_id) 
         
-            yield from task_iterator(dep, only_non_complete=only_non_complete, already_seen_tasks)
+            yield from task_iterator(dep, only_non_complete=only_non_complete, already_seen_tasks=already_seen_tasks)
 
 
 def get_all_output_files_in_tree(root_module, key=None):

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -139,14 +139,15 @@ def flatten_to_list_of_dicts(inputs):
     return dict(joined_dict)
 
 
-def task_iterator(task, only_non_complete=False, already_seen_tasks = set()):
+def task_iterator(task, only_non_complete=False, already_seen_tasks=None):
+    if already_seen_tasks is None:
+        already_seen_tasks = set()
     if not only_non_complete or not task.complete():
         yield task
         for dep in task.deps():
             if dep.task_id in already_seen_tasks:
                 continue
-            already_seen_tasks.add(dep.task_id) 
-        
+            already_seen_tasks.add(dep.task_id)
             yield from task_iterator(dep, only_non_complete=only_non_complete, already_seen_tasks=already_seen_tasks)
 
 

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -150,11 +150,13 @@ def task_iterator(task, only_non_complete=False):
         if only_non_complete and task.complete():
             return
 
+        yield task
+
         for dep in task.deps():
             if dep.task_id in already_seen_tasks:
                 continue
             already_seen_tasks.add(dep.task_id)
-            yield from _unique_task_iterator(dep, only_non_complete=only_non_complete, already_seen_tasks=already_seen_tasks)
+            yield from _unique_task_iterator(dep, only_non_complete=only_non_complete)
 
     yield from _unique_task_iterator(task, only_non_complete)
 

--- a/b2luigi/core/utils.py
+++ b/b2luigi/core/utils.py
@@ -139,11 +139,15 @@ def flatten_to_list_of_dicts(inputs):
     return dict(joined_dict)
 
 
-def task_iterator(task, only_non_complete=False):
+def task_iterator(task, only_non_complete=False, already_seen_tasks = set()):
     if not only_non_complete or not task.complete():
         yield task
         for dep in task.deps():
-            yield from task_iterator(dep, only_non_complete=only_non_complete)
+            if dep.task_id in already_seen_tasks:
+                continue
+            already_seen_tasks.add(dep.task_id) 
+        
+            yield from task_iterator(dep, only_non_complete=only_non_complete, already_seen_tasks)
 
 
 def get_all_output_files_in_tree(root_module, key=None):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,7 @@ Features, fixing, help and testing
     * Matthias Schnepf  (`mschnepf`_)
     * Artur Gottmann (`ArturAkh`_)
     * Caspar Schmitt (`schmitca`_)
+    * Marcel Hohmann (`MarcelHoh_`)
 
 Stolen ideas
     * Implementation of SGE batch system (`sge`_).
@@ -157,6 +158,7 @@ Stolen ideas
 .. _`ArturAkh`: https://github.com/ArturAkh
 .. _`mschnepf`: https://github.com/mschnepf
 .. _`schmitca`: https://github.com/schmitca
+.. _`MarcelHoh`: https://github.com/MarcelHoh
 .. _`sge`: https://github.com/spotify/luigi/blob/master/luigi/contrib/sge.py
 .. _`lsf`: https://github.com/spotify/luigi/pull/2373/files
 


### PR DESCRIPTION
On the batch workers the graph is locally reproduced until the task_id of the task to run is found. In doing so if N tasks require a common input file that task and the structure of tasks it requires will be traversed N times. 

This PR adds a simple  set that stores what tasks have already been checked. And only checks the required tasks if the parent task has not already been seen.