### PR TITLE
Bump to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.9.0] - 2023-03-20
+
 ### Fixed
 
 - **gbasf2**: Fix bug introduced in [#181](https://github.com/nils-braun/b2luigi/pull/181) when generating basf2 queries with just a simple `.root` extension, raising a wrong false positive errors. Now moved splitting functionality into separate function and added extensive unit tests. Thanks @schmitca for reporting [#184](https://github.com/nils-braun/b2luigi/pull/184).
@@ -16,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `task_iterator` now returns a unique list of tasks. The task graph is a DAG which is traversed through recursion in `task_iterator` like a tree. If multiple tasks had the same task as a requirement (i.e. multiple nodes share a child), it was returned multiple times in the task iterator. This results in performance improvements when checking the requirements. [#186](https://github.com/nils-braun/b2luigi/pull/186). Thanks [@MarcelHoh](https://github.com/MarcelHoh) for the initial PR.
 
-**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.8.2...main
+**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.8.2...v0.9.0
 
 ## [0.8.2] - 2023-01-13
 

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -2,20 +2,21 @@
 from luigi import *
 from luigi.util import copies
 
+from b2luigi.cli.process import process
+from b2luigi.core.dispatchable_task import DispatchableTask, dispatch
+from b2luigi.core.settings import clear_setting, get_setting, set_setting
+from b2luigi.core.task import ExternalTask, Task, WrapperTask
+from b2luigi.core.temporary_wrapper import on_temporary_files
+
 # version must be defined after importing the luigi namespace,
 # otherwise the b2luigi.__version__ gets overwritten by the one from luigi
-__version__ = "0.8.2"
+__version__ = "0.9.0"
 
-from b2luigi.core.parameter import wrap_parameter, BoolParameter
-from typing import Optional, Union, Collection
+from typing import Collection, Optional, Union
+
+from b2luigi.core.parameter import BoolParameter, wrap_parameter
 
 wrap_parameter()
-
-from b2luigi.core.task import Task, ExternalTask, WrapperTask
-from b2luigi.core.temporary_wrapper import on_temporary_files
-from b2luigi.core.dispatchable_task import DispatchableTask, dispatch
-from b2luigi.core.settings import get_setting, set_setting, clear_setting
-from b2luigi.cli.process import process
 
 
 class requires(object):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,8 @@
 
 # -- Project information -----------------------------------------------------
 
+import os
+
 project = 'b2luigi'
 copyright = '2018, Nils Braun'
 author = 'Nils Braun'
@@ -26,7 +28,7 @@ author = 'Nils Braun'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.8.2'
+release = '0.9.0'
 
 
 # -- General configuration ---------------------------------------------------
@@ -160,7 +162,6 @@ texinfo_documents = [
 
 # Cheating around read the docs: we need to install our project which is not possible because we
 # have no setup.py. But this should work...
-import os
 
 if os.getenv("READTHEDOCS"):
     import subprocess


### PR DESCRIPTION
The change to the `task_iterator` to give a unique list of tasks instead of repeating tasks when nodes share children affects all remote batch submissions. It should not break submission, just improve submission performance. But is a change in the behavior of a public-facing function and therefore changing the minor digit of the version is warranted.