### PR TITLE
add ability to pass a custom hash function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- added the ability to pass a custom hashing function to parameters via the `hash_function` keyword argument. [#189](https://github.com/nils-braun/b2luigi/pull/189). The function must take one argument, the value of the parameter. It is up to the user to ensure unique strings are created.
+
 ## [0.9.0] - 2023-03-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- added the ability to pass a custom hashing function to parameters via the `hash_function` keyword argument. [#189](https://github.com/nils-braun/b2luigi/pull/189). The function must take one argument, the value of the parameter. It is up to the user to ensure unique strings are created.
+- Add the ability to pass a custom hashing function to parameters via the `hash_function` keyword argument. [#189](https://github.com/nils-braun/b2luigi/pull/189). The function must take one argument, the value of the parameter. It is up to the user to ensure unique strings are created.
 
 ## [0.9.0] - 2023-03-20
 

--- a/b2luigi/core/parameter.py
+++ b/b2luigi/core/parameter.py
@@ -2,16 +2,22 @@ import hashlib
 
 import luigi
 from luigi.parameter import _no_value
+from inspect import signature
 
 
 def wrap_parameter():
     """
     Monkey patch the parameter base class (and with it all other parameters(
-    of luigi to include an additional "hashed" parameter in its constructor.
+    of luigi to include two additional parameters in its constructor:
+    "hashed" and "hash_function".
 
-    Enabling this parameter will use a hashed version of the parameter value
-    when creating file paths our of the parameters of a task instead of the
-    value itself.
+    Enabling the "hashed" parameter will use a hashed version of the
+    parameter value when creating file paths our of the parameters of a task
+    instead of the value itself. By default an md5 hash is used. A custom
+    hash function can be provided via the "hash_function" parameter. This
+    function should take one input, the value of the parameter. It is up
+    to the user to ensure a unique string is created from the input.
+
     This is especially useful when you have list, string or dict parameters,
     where the resulting file path may include "/" or "{}".
     """
@@ -19,12 +25,22 @@ def wrap_parameter():
     parameter_class = b2luigi.Parameter
 
     def serialize_hashed(self, x):
-        return "hashed_" + hashlib.md5(str(x).encode()).hexdigest()
+        if self.hash_function is None:
+            return "hashed_" + hashlib.md5(str(x).encode()).hexdigest()
+        else:
+            return self.hash_function(x)
 
     old_init = parameter_class.__init__
 
-    def __init__(self, hashed=False, *args, **kwargs):
+    def __init__(self, hashed=False, hash_function=None, *args, **kwargs):
         old_init(self, *args, **kwargs)
+
+        if self.hash_function is not None:
+            n_params = len(signature(hash_function).params)
+            assert  n_params == 1, f"Custom hash function can have only"\
+                " 1 argument, found {n_params}"
+
+        self.hash_function = hash_function
 
         if hashed:
             self.serialize_hashed = lambda x: serialize_hashed(self, x)

--- a/b2luigi/core/parameter.py
+++ b/b2luigi/core/parameter.py
@@ -35,10 +35,10 @@ def wrap_parameter():
     def __init__(self, hashed=False, hash_function=None, *args, **kwargs):
         old_init(self, *args, **kwargs)
 
-        if self.hash_function is not None:
-            n_params = len(signature(hash_function).params)
-            assert  n_params == 1, f"Custom hash function can have only"\
-                " 1 argument, found {n_params}"
+        if hash_function is not None:
+            n_params = len(signature(hash_function).parameters)
+            assert n_params == 1, "Custom hash function can have only"\
+                f" 1 argument, found {n_params}"
 
         self.hash_function = hash_function
 

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -2,8 +2,10 @@ import b2luigi
 
 from ..helpers import B2LuigiTestCase
 
+
 def custom_hash_function(x):
-    return "_".join(x)
+    return "_".join([str(y) for y in x])
+
 
 class HashedParameterTestCase(B2LuigiTestCase):
     def test_hash_consistency(self):
@@ -26,14 +28,13 @@ class HashedParameterTestCase(B2LuigiTestCase):
         self.assertEqual(serialized_first, "hashed_7816c14282fd03e3dc4e398f28aa5a30")
 
         third_parameter = b2luigi.ListParameter(hashed=True, hash_function=custom_hash_function)
-        serialized = third_parameter.serialize_hashed([0,1,2])
+        serialized = third_parameter.serialize_hashed([0, 1, 2])
         self.assertEqual(serialized, "0_1_2")
-
 
     def test_with_task(self):
         class MyTask(b2luigi.Task):
             my_parameter = b2luigi.ListParameter(hashed=True)
-            custom_hashed_parameter = b2luigi.ListParameter(hashed=True, hash_function = custom_hash_function)
+            custom_hashed_parameter = b2luigi.ListParameter(hashed=True, hash_function=custom_hash_function)
 
             def run(self):
                 with open(self.get_output_file_name("test.txt"), "w") as f:
@@ -42,7 +43,8 @@ class HashedParameterTestCase(B2LuigiTestCase):
             def output(self):
                 yield self.add_to_output("test.txt")
 
-        task = MyTask(my_parameter=["Some", "strange", "items", "with", "bad / signs"], custom_hashed_parameter=[0,1,2])
+        task = MyTask(my_parameter=["Some", "strange", "items", "with", "bad / signs"], custom_hashed_parameter=[0, 1, 2])
 
         self.assertTrue(task.get_output_file_name("test.txt")
-                        .endswith("results/my_parameter=hashed_08928069d368e4a0f8ac02a0193e443b/custom_hashed_parameter=0_1_2/test.txt"))
+                        .endswith("results/my_parameter=hashed_08928069d368e4a0f8ac02a0193e443b"
+                                  "/custom_hashed_parameter=0_1_2/test.txt"))

--- a/tests/core/test_parameter.py
+++ b/tests/core/test_parameter.py
@@ -45,6 +45,5 @@ class HashedParameterTestCase(B2LuigiTestCase):
 
         task = MyTask(my_parameter=["Some", "strange", "items", "with", "bad / signs"], custom_hashed_parameter=[0, 1, 2])
 
-        self.assertTrue(task.get_output_file_name("test.txt")
-                        .endswith("results/my_parameter=hashed_08928069d368e4a0f8ac02a0193e443b"
-                                  "/custom_hashed_parameter=0_1_2/test.txt"))
+        expected_path = "results/my_parameter=hashed_08928069d368e4a0f8ac02a0193e443b/custom_hashed_parameter=0_1_2/test.txt"
+        self.assertTrue(task.get_output_file_name("test.txt").endswith(expected_path))


### PR DESCRIPTION
I often find myself getting a bit annoyed at just how human unfriendly the hashed parameters are. In many cases, while the set of parameters might be a large dictionary,  I can produce a unique string which allows me to identify the exact parameters passed, or it would be useful to just prepend a little information to a hash to make it easier to identify broad groups of tasks.

This PR adds the ability to use a custom hash function, for hashed parameters. This can be as easy as just joining the values of a list parameter with ```"_".join(x)```. It is up to the user to ensure that no duplicates are created and that names are of a reasonable length. The default behaviour remains unchanged. 