### PR TITLE
Fix circular import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Fixed
+
+- Fix circular import [#188](https://github.com/nils-braun/b2luigi/issues/188)
+
 ### Added
 
-- Add the ability to pass a custom hashing function to parameters via the `hash_function` keyword argument. [#189](https://github.com/nils-braun/b2luigi/pull/189). The function must take one argument, the value of the parameter. It is up to the user to ensure unique strings are created.
+- Add the ability to pass a custom hashing function to parameters via the `hash_function` keyword argument. The function must take one argument, the value of the parameter. It is up to the user to ensure unique strings are created. [#189](https://github.com/nils-braun/b2luigi/pull/189)
+
+**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.9.0...main
+
 
 ## [0.9.0] - 2023-03-20
 

--- a/b2luigi/__init__.py
+++ b/b2luigi/__init__.py
@@ -2,21 +2,20 @@
 from luigi import *
 from luigi.util import copies
 
-from b2luigi.cli.process import process
-from b2luigi.core.dispatchable_task import DispatchableTask, dispatch
-from b2luigi.core.settings import clear_setting, get_setting, set_setting
-from b2luigi.core.task import ExternalTask, Task, WrapperTask
-from b2luigi.core.temporary_wrapper import on_temporary_files
-
 # version must be defined after importing the luigi namespace,
 # otherwise the b2luigi.__version__ gets overwritten by the one from luigi
 __version__ = "0.9.0"
 
-from typing import Collection, Optional, Union
-
-from b2luigi.core.parameter import BoolParameter, wrap_parameter
+from b2luigi.core.parameter import wrap_parameter, BoolParameter
+from typing import Optional, Union, Collection
 
 wrap_parameter()
+
+from b2luigi.core.task import Task, ExternalTask, WrapperTask
+from b2luigi.core.temporary_wrapper import on_temporary_files
+from b2luigi.core.dispatchable_task import DispatchableTask, dispatch
+from b2luigi.core.settings import get_setting, set_setting, clear_setting
+from b2luigi.cli.process import process
 
 
 class requires(object):


### PR DESCRIPTION
This reverts parts of commit 

In commit b80fbedb8a78633524f1eb326ca56f314599cb5d, in addition to bumping the version of b2luigi, I accidentally committed the import sorting done by isort in my editor. That resulted in a circular import. As I thought of this as just a version bump, I didn't look at the test results.

As a fix, I reverted the changes from that commit to the `__init__.py`, except the version bump.

Thanks @MarcelHoh for reporting.

Resolves #188.