### PR TITLE
Better basf2-related docs, examples and change how basf2 release hash is calculated for local releases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Changed
 
-- For local basf2 versions, change how hash for `basf2_release` Parameter is calculated. Now use basf2 functionality to get the version, to be consistent with the output of `basf2 --version`. The new hash encodes both the local and central basf2 release, the basf2 function [`getCommitID`](https://github.com/belle2/basf2/blob/1c972b2c89ef11f38ee2f5ea8eb562dde0637155/framework/io/include/RootIOUtilities.h#L77-L84). Thanks to @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193).
+- For local basf2 versions, change how hash for `basf2_release` Parameter is calculated. Now use basf2 functionality to get the version, to be consistent with the output of `basf2 --version`. The new hash encodes both the local and central basf2 release, the basf2 function [`getCommitID`](https://github.com/belle2/basf2/blob/1c972b2c89ef11f38ee2f5ea8eb562dde0637155/framework/io/include/RootIOUtilities.h#L77-L84). When basf2 is not set up, print warning before returning `"not_set"`. Thanks to @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193).
 
   **Warning:** If you use local basf2 versions, that is your `basf2_release` is a git hash, this will change your b2luigi target output paths. This means that tasks that were marked _complete_, might suddenly not be _complete_ anymore after updating to this release. A workaround is to check for the new expected path via `python3 <steering_fname>.py --show_output` and rename the `git_hash=<…>` directory.
 
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Fixed
 
-- Fix example `SimulationTask` task in `basf2_chain_example.py`, which probably wasn't warking as it was missing the Geometry module. Also by @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193)
+- Fix example `SimulationTask` task in `basf2_chain_example.py`, which probably wasn't working as it was missing the Geometry module. Also by @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193)
 
 
 **Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.9.1...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## Changed
+
+- For local basf2 versions, change how hash for `basf2_release` Parameter is calculated. Now use basf2 functionality to get the version, to be consistent with the output of `basf2 --version`. The new hash encodes both the local and central basf2 release, the basf2 function [`getCommitID`](https://github.com/belle2/basf2/blob/1c972b2c89ef11f38ee2f5ea8eb562dde0637155/framework/io/include/RootIOUtilities.h#L77-L84). Thanks to @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193).
+
+  **Warning:** If you use local basf2 versions, that is your `basf2_release` is a git hash, this will change your b2luigi target output paths. This means that tasks that were marked _complete_, might suddenly not be _complete_ anymore after updating to this release. A workaround is to check for the new expected path via `python3 <steering_fname>.py --show_output` and rename the `git_hash=<…>` directory.
+
+- Apply `max_events` Parameter not by changing the environment singleton, but instead forward it to `basf2.process` call. This should hopefully not affect the behaviour in practice. Also by @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193)
+
+- Refactor the basf2 related examples to use more idiomatic, modern basf2 code, e.g. using `basf2.Path()` instead of `basf2.create_path()`. . Also by @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193)
+
+## Fixed
+
+- Fix example `SimulationTask` task in `basf2_chain_example.py`, which probably wasn't warking as it was missing the Geometry module. Also by @GiacomoXT in [#193](https://github.com/nils-braun/b2luigi/issues/193)
+
+
+**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.9.1...main
+
 ## [0.9.1] - 2023-03-20
 
 ### Fixed
@@ -19,7 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add the ability to pass a custom hashing function to parameters via the `hash_function` keyword argument. The function must take one argument, the value of the parameter. It is up to the user to ensure unique strings are created. [#189](https://github.com/nils-braun/b2luigi/pull/189)
 - **gbasf2**: Switch to the `--new` flag in `gb2_ds_get` which downloads files significantly faster than previously. Gbasf2 release v5r6 (November 2022) is required. [#190](https://github.com/nils-braun/b2luigi/pull/190).
 
-**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.9.1...v0.9.0
+**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.9.0...v0.9.1
 
 ## [0.9.0] - 2023-03-20
 

--- a/b2luigi/basf2_helper/tasks.py
+++ b/b2luigi/basf2_helper/tasks.py
@@ -46,21 +46,17 @@ class Basf2PathTask(Basf2Task):
 
         try:
             import basf2
-            import ROOT
         except ImportError:
             raise ImportError("Can not find ROOT or basf2. Can not use the basf2 task.")
 
         if self.num_processes:
             basf2.set_nprocesses(self.num_processes)
 
-        if self.max_event:
-            ROOT.Belle2.Environment.Instance().setNumberEventsOverride(self.max_event)
-
         path = self.create_path()
 
         path.add_module("Progress")
         basf2.print_path(path)
-        basf2.process(path)
+        basf2.process(path=path, max_event=self.max_event if self.max_event else 0)
 
         print(basf2.statistics)
 

--- a/b2luigi/basf2_helper/utils.py
+++ b/b2luigi/basf2_helper/utils.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 
 def get_basf2_git_hash():
@@ -21,5 +22,9 @@ def get_basf2_git_hash():
         if hasattr(basf2.version, "get_version"):
             return basf2.version.get_version()
         return basf2.version.version
-    except ImportError:
+    except ImportError as err:
+        warnings.warn(
+            f"No basf2 was found. Setting basf2 git hash to \"not_set\": \n {err}",
+            category=ImportWarning,
+        )
         return "not_set"

--- a/b2luigi/basf2_helper/utils.py
+++ b/b2luigi/basf2_helper/utils.py
@@ -2,17 +2,24 @@ import os
 
 
 def get_basf2_git_hash():
+    """Return name of basf2 release or if local basf2 is used its version hash.
+
+    The version is equivalent to the version returned by ``basf2 --version``.
+
+    Returns ``\"not set\"``, if no basf2 release is set and basf2 cannot be imported.
+    """
     basf2_release = os.getenv("BELLE2_RELEASE")
 
-    if basf2_release == "head" or basf2_release is None:
-
-        try:
-            from basf2.version import get_version
-            basf2_hash = get_version
-        except ImportError:
-            from basf2.version import version
-            basf2_hash = version
-
-        basf2_release = basf2_hash()
-
-    return basf2_release
+    if basf2_release not in ("head", None):
+        return basf2_release
+    # else if BASF2_RELEASE environment variable is not set, get version hash of
+    # local basf2
+    try:
+        import basf2.version
+        # try both get_version method and version attribute, one of which
+        # should work depending on basf2 release
+        if hasattr(basf2.version, "get_version"):
+            return basf2.version.get_version()
+        return basf2.version.version
+    except ImportError:
+        return "not_set"

--- a/b2luigi/basf2_helper/utils.py
+++ b/b2luigi/basf2_helper/utils.py
@@ -1,16 +1,18 @@
 import os
 
-import git
-
 
 def get_basf2_git_hash():
     basf2_release = os.getenv("BELLE2_RELEASE")
 
     if basf2_release == "head" or basf2_release is None:
-        basf2_release_location = os.getenv("BELLE2_LOCAL_DIR")
 
-        if basf2_release_location:
-            return git.Repo(basf2_release_location).head.object.hexsha
-        return "not_set"
+        try:
+            from basf2.version import get_version
+            basf2_hash = get_version
+        except ImportError:
+            from basf2.version import version
+            basf2_hash = version
+
+        basf2_release = basf2_hash()
 
     return basf2_release

--- a/docs/advanced/basf2-examples.rst
+++ b/docs/advanced/basf2-examples.rst
@@ -115,7 +115,7 @@ nTuple Generation
             # (parameters just examples)
             input_file_names = ..
 
-            path = basf2.create_path()
+            path = basf2.Path()
             modularAnalysis.inputMdstList('default', input_file_names, path=path)
 
             # Now fill your particle lists, just examples

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,6 +136,7 @@ Features, fixing, help and testing
     * Artur Gottmann (`ArturAkh`_)
     * Caspar Schmitt (`schmitca`_)
     * Marcel Hohmann (`MarcelHoh_`)
+    * Giacomo De Pietro (`GiacomoXT_`)
 
 Stolen ideas
     * Implementation of SGE batch system (`sge`_).
@@ -159,6 +160,7 @@ Stolen ideas
 .. _`mschnepf`: https://github.com/mschnepf
 .. _`schmitca`: https://github.com/schmitca
 .. _`MarcelHoh`: https://github.com/MarcelHoh
+.. _`GiacomoXT`: https://github.com/GiacomoXT
 .. _`sge`: https://github.com/spotify/luigi/blob/master/luigi/contrib/sge.py
 .. _`lsf`: https://github.com/spotify/luigi/pull/2373/files
 

--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -27,10 +27,15 @@ class SimulationTask(Basf2PathTask):
         modularAnalysis.setupEventInfo(self.n_events, path)
 
         if self.event_type == SimulationType.y4s:
-            # in current main branch and release 5 the Y(4S)decay file is moved, so try old and new locations
-            find_file_ignore_error = True
-            dec_file = basf2.find_file('analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec',
-                                       silent=find_file_ignore_error)
+            # In current main branch and release 5 the Y(4S)decay file is moved,
+            # so try old and new locations.
+
+            # With ``silent=True``, ``find_file`` returns empty string if nothing is
+            # found. With ``silent=False``, a ``FileNotFoundError`` exception is
+            # raised.
+            dec_file = basf2.find_file(
+                'analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec', silent=True
+            )
             if not dec_file:
                 dec_file = basf2.find_file('analysis/examples/simulations/B2A101-Y4SEventGeneration.dec')
         elif self.event_type == SimulationType.continuum:

--- a/examples/basf2/basf2_chain_example.py
+++ b/examples/basf2/basf2_chain_example.py
@@ -31,7 +31,7 @@ class SimulationTask(Basf2PathTask):
             find_file_ignore_error = True
             dec_file = basf2.find_file('analysis/examples/tutorials/B2A101-Y4SEventGeneration.dec',
                                        silent=find_file_ignore_error)
-            if dec_file == '':
+            if not dec_file:
                 dec_file = basf2.find_file('analysis/examples/simulations/B2A101-Y4SEventGeneration.dec')
         elif self.event_type == SimulationType.continuum:
             dec_file = basf2.find_file('analysis/examples/simulations/B2A102-ccbarEventGeneration.dec')

--- a/examples/gbasf2/example_mdst_analysis.py
+++ b/examples/gbasf2/example_mdst_analysis.py
@@ -5,7 +5,6 @@ analysis path be imported from gbasf2_example.py
 """
 
 import basf2
-import ROOT  # noqa: F401
 import modularAnalysis as mA
 import vertex as vx
 from stdCharged import stdK, stdPi
@@ -22,7 +21,7 @@ def create_analysis_path(
     parameter, adapted from code in the ``B2T_Basics_3_FirstAnalysis.ipynb``
     notebook from b2 starter kit.
     """
-    path = basf2.create_path()
+    path = basf2.Path()
     # this local inputMdstList will only be used when this steerig file is run locally, gbasf2 overrides it
     local_input_files = ["/group/belle2/dataprod/MC/MC13a/prod00009434/s00/e1003/4S/r00000/mixed/mdst/sub00/mdst_000001_prod00009434_task10020000001.root"]
     mA.inputMdstList(

--- a/tests/basf2_helper/test_utils.py
+++ b/tests/basf2_helper/test_utils.py
@@ -1,4 +1,7 @@
 import os
+import sys
+import warnings
+
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -11,7 +14,9 @@ class TestGetBasf2GitHash(TestCase):
         On CI systems no basf2 is installed or set up, so ``get_basf2_git_hash``
         should return \"not set\".
         """
-        self.assertEqual(get_basf2_git_hash(), "not_set")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=ImportWarning)
+            self.assertEqual(get_basf2_git_hash(), "not_set")
 
     def test_return_no_set_warning(self):
         """
@@ -24,3 +29,28 @@ class TestGetBasf2GitHash(TestCase):
     @patch.dict(os.environ, {"BELLE2_RELEASE": "belle2_release_xy"})
     def test_belle2_release_env_is_set(self):
         self.assertEqual(get_basf2_git_hash(), "belle2_release_xy")
+
+    def test_basf2_hash_from_get_version(self):
+        "In older basf2 releases we get version from ``basf2.version.get_version``."
+        class MockVersion:
+            @staticmethod
+            def get_version():
+                return "some_basf2_version"
+
+        class MockBasf2:
+            version = MockVersion
+
+        with patch.dict(sys.modules, {"basf2": MockBasf2, "basf2.version": MockVersion}):
+            self.assertEqual(get_basf2_git_hash(), "some_basf2_version")
+
+    def test_basf2_hash_from_version_property(self):
+        "In newer basf2 releases we get version from ``basf2.version.version``."
+
+        class MockVersion:
+            version = "another_basf2_version"
+
+        class MockBasf2:
+            version = MockVersion
+
+        with patch.dict(sys.modules, {"basf2": MockBasf2, "basf2.version": MockVersion}):
+            self.assertEqual(get_basf2_git_hash(), "another_basf2_version")

--- a/tests/basf2_helper/test_utils.py
+++ b/tests/basf2_helper/test_utils.py
@@ -1,0 +1,26 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from b2luigi.basf2_helper.utils import get_basf2_git_hash
+
+
+class TestGetBasf2GitHash(TestCase):
+    def test_return_no_set(self):
+        """
+        On CI systems no basf2 is installed or set up, so ``get_basf2_git_hash``
+        should return \"not set\".
+        """
+        self.assertEqual(get_basf2_git_hash(), "not_set")
+
+    def test_return_no_set_warning(self):
+        """
+        On CI systems no basf2 is installed or set up, so ``get_basf2_git_hash``
+        should print an ``ImportWarning``.
+        """
+        with self.assertWarns(ImportWarning):
+            get_basf2_git_hash()
+
+    @patch.dict(os.environ, {"BELLE2_RELEASE": "belle2_release_xy"})
+    def test_belle2_release_env_is_set(self):
+        self.assertEqual(get_basf2_git_hash(), "belle2_release_xy")


### PR DESCRIPTION
Top-level `import ROOT` is very nasty and it must be avoided as much as possible. So, I removed them.

Moreover, better not to invoke the Environment singleton, but to directly use the parmaeter in `basf2.process` for the maximum number of events.

And in case it's not evident, I don't like `basf2.create_path()`. :D