### PR TITLE
Update version of codecov github action from v1 to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,7 @@ jobs:
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
+      with:
+        flags: unittests
+        verbose: true


### PR DESCRIPTION
v1 is being deprecated, see
https://about.codecov.io/blog/introducing-codecovs-new-uploader
https://github.com/marketplace/actions/codecov

Codecov is used to check the test coverage on every PR and it is also displayed as a shield in the github README. I haven't checked yet if that shield or even the actions work just with updating the version string, not sure if I can test that without merging the PR. 

Resolves #198