### PR TITLE
Add gbasf2_setup_path as an argument to several functions requiring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Older entries have been generated from github releases.
 New entries aim to adhere to the format proposed by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+  [#203](https://github.com/nils-braun/b2luigi/pull/203) @AlexanderHeidelbach
+* **gbasf2:** Fix `gbasf2_setup_path` setting not being passed through in some function calls.
+
+**Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.10.1...main
+
 ## [0.10.1] - 2023-04-17
 
 ### Added

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -406,7 +406,7 @@ class Gbasf2Process(BatchProcess):
         Things to do after the project failed
         """
         job_status_dict = get_gbasf2_project_job_status_dict(
-            self.gbasf2_project_name, dirac_user=self.dirac_user
+            self.gbasf2_project_name, dirac_user=self.dirac_user, gbasf2_setup_path=self.gbasf2_setup_path
         )
         failed_job_dict = {
             job_id: job_info
@@ -1219,7 +1219,7 @@ def get_dirac_user(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.
     """Get dirac user name."""
     # ensure proxy is initialized, because get_proxy_info can't do it, otherwise
     # it causes an infinite loop
-    setup_dirac_proxy()
+    setup_dirac_proxy(gbasf2_setup_path)
     try:
         proxy_info = get_proxy_info(gbasf2_setup_path)
         return proxy_info["username"]
@@ -1233,7 +1233,7 @@ def setup_dirac_proxy(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/set
     """Run ``gb2_proxy_init -g belle`` if there's no active dirac proxy. If there is, do nothing."""
     # first run script to check if proxy is already alive or needs to be initalized
     try:
-        if get_proxy_info()["secondsLeft"] > 3600 * get_setting(
+        if get_proxy_info(gbasf2_setup_path)["secondsLeft"] > 3600 * get_setting(
             "gbasf2_min_proxy_lifetime", default=0
         ):
             return

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,6 +137,7 @@ Features, fixing, help and testing
     * Caspar Schmitt (`schmitca`_)
     * Marcel Hohmann (`MarcelHoh_`)
     * Giacomo De Pietro (`GiacomoXT_`)
+    * Alex Heidelbach (`AlexanderHeidelbach_`)
 
 Stolen ideas
     * Implementation of SGE batch system (`sge`_).
@@ -161,6 +162,7 @@ Stolen ideas
 .. _`schmitca`: https://github.com/schmitca
 .. _`MarcelHoh`: https://github.com/MarcelHoh
 .. _`GiacomoXT`: https://github.com/GiacomoXT
+.. _`AlexanderHeidelbach`: https://github.com/AlexanderHeidelbach
 .. _`sge`: https://github.com/spotify/luigi/blob/master/luigi/contrib/sge.py
 .. _`lsf`: https://github.com/spotify/luigi/pull/2373/files
 


### PR DESCRIPTION
Some functions did not propagate the gbasf2_setup_path correctly to all functions in their execution. This causes the default gbasf2 setup to be invoked instead of the custom setting. I tested the behaviour with the currently broken gbasf2 setup script and a custom version and now submission is possible with the custom script..