### PR TITLE
Inherit local basf2 log level in gbasf2 grid jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   [#203](https://github.com/nils-braun/b2luigi/pull/203) @AlexanderHeidelbach
 * **gbasf2:** Fix `gbasf2_setup_path` setting not being passed through in some function calls.
+* **gbasf2:** Local basf2 log level setting is now passed over to the grid jobs. You can now limit the log size of jobs with many warnings via `basf2.set_log_level(basf2.LogLevel.ERROR)`. This could fix some errors due to too large log sizes. Implemented by pickling local `basf2.logging.log_level`.
 
 **Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.10.1...main
 

--- a/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
+++ b/b2luigi/batch/processes/gbasf2_utils/pickle_utils.py
@@ -1,6 +1,6 @@
 import pickle
 
-from basf2 import conditions as b2conditions
+from basf2 import conditions as b2conditions, logging
 from basf2.pickle_path import serialize_path
 from variables import variables as vm
 
@@ -16,7 +16,7 @@ def get_alias_dict_from_variable_manager():
 
 def write_path_and_state_to_file(basf2_path, file_path):
     """
-    Serialize basf2 path and variables from variable manager to file.
+    Serialize basf2 path, aliases and log_level to file.
 
     Variant of ``basf2.pickle_path.write_path_to_file``, only with additional
     serialization of the basf2 variable aliases and global tags.
@@ -32,5 +32,6 @@ def write_path_and_state_to_file(basf2_path, file_path):
         serialized = serialize_path(basf2_path)
         serialized["aliases"] = get_alias_dict_from_variable_manager()
         serialized["globaltags"] = b2conditions.globaltags
+        serialized["log_level"] = logging.log_level
         # serialized["conditions"] = b2conditions
         pickle.dump(serialized, pickle_file)

--- a/b2luigi/batch/processes/templates/gbasf2_steering_file_wrapper.jinja2
+++ b/b2luigi/batch/processes/templates/gbasf2_steering_file_wrapper.jinja2
@@ -40,6 +40,16 @@ def get_global_tags_from_file(file_path):
     except KeyError:
         pass
 
+def set_log_level_from_file(file_path):
+    """
+    Extract and set global basf2 log level from pickle file.
+    """
+    with open(file_path, 'br') as pickle_file:
+        serialized = pickle.load(pickle_file)
+    try:
+        basf2.set_log_level(serialized["log_level"])
+    except KeyError:
+        pass
 
 pickle_file_path = "{{ pickle_file_path }}"
 if not os.path.isfile(pickle_file_path):
@@ -47,6 +57,8 @@ if not os.path.isfile(pickle_file_path):
 
 apply_alias_dict_from_file(pickle_file_path)
 get_global_tags_from_file(pickle_file_path)
+set_log_level_from_file(pickle_file_path)
+
 path = b2pp.get_path_from_file(pickle_file_path)
 
 basf2.print_path(path)


### PR DESCRIPTION
Local basf2 log level setting is now passed over to the grid jobs. You can now limit the log size of jobs with many warnings via `basf2.set_log_level(basf2.LogLevel.ERROR)`. This could fix some errors due to too large log sizes. Implemented by pickling local `basf2.logging.log_level`.

I would need somebody for testing this...