### PR TITLE
Feature/update default gbasf2 cvmfs setup script path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Cache pip
       uses: actions/cache@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,22 @@
 # basic checks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
+  - id: check-ast
   - id: check-yaml
   - id: check-json
   - id: check-toml
-  - id: end-of-file-fixer
-    exclude: ^tests/batch/_gbasf2_project_download_stdouts/
   - id: trailing-whitespace
   - id: check-added-large-files
   - id: check-symlinks
   - id: no-commit-to-branch
+  - id: end-of-file-fixer
+    exclude: ^tests/batch/_gbasf2_project_download_stdouts/
+  - id: fix-byte-order-marker
 
 - repo: https://github.com/pycqa/flake8
-  rev: 5.0.4
+  rev: 6.1.0
   hooks:
   - id: flake8
     name: Check syntax and style with flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [#203](https://github.com/nils-braun/b2luigi/pull/203) @AlexanderHeidelbach
 * **gbasf2:** Fix `gbasf2_setup_path` setting not being passed through in some function calls.
 
+### Changed
+
+* **gbasf2:** Change the default gbasf2 setup script path to CVMFS location in gbasf2 v5.8.2, i.e.
+  ```
+  /cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc
+  ```
+  Reminder that this can still be customized via the `gbasf2_setup_path` setting. Resolves issue ![#206](https://github.com/nils-braun/b2luigi/issues/206).
+
 ### Removed
+
 * **gbasf2:** Fully deprecate `gbasf2_install_directory` setting. It will be ignored from now on and a warning given if used. Instead please use the `gbasf2_setup_path` setting introduced in v0.10.1 to provide the exact path to the gbasf2 setup script. `gbasf2_install_directory` will not be used as a fall-back anymore as was the case in v0.10.1.
 
 **Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.10.1...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [#203](https://github.com/nils-braun/b2luigi/pull/203) @AlexanderHeidelbach
 * **gbasf2:** Fix `gbasf2_setup_path` setting not being passed through in some function calls.
 
+### Removed
+* **gbasf2:** Fully deprecate `gbasf2_install_directory` setting. It will be ignored from now on and a warning given if used. Instead please use the `gbasf2_setup_path` setting introduced in v0.10.1 to provide the exact path to the gbasf2 setup script. `gbasf2_install_directory` will not be used as a fall-back anymore as was the case in v0.10.1.
+
 **Full Changelog**: https://github.com/nils-braun/b2luigi/compare/v0.10.1...main
 
 ## [0.10.1] - 2023-04-17

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -231,12 +231,19 @@ class Gbasf2Process(BatchProcess):
         # Setting it via a setting.json file is not supported to make sure users set unique project names
         self.gbasf2_project_name = get_unique_project_name(self.task)
 
-
         self.gbasf2_setup_path = get_setting(
             "gbasf2_setup_path",
             default="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
             task=self.task,
         )
+
+        if not os.path.isfile(self.gbasf2_setup_path):
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT),
+                f"File not found: {self.gbasf2_setup_path}.\n"
+                "Maybe you need to customize the `gbasf2_setup_path` setting?\n"
+                "That is sometimes necessary when file location changed between gbasf2 releases."
+            )
 
         if get_setting(
             "gbasf2_install_directory",

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -139,7 +139,7 @@ class Gbasf2Process(BatchProcess):
         Other not required, but noteworthy settings are:
 
         - ``gbasf2_setup_path``: Path to gbasf2 environment setup script that needs so be sourced to run gbasf2 commands.
-            Defaults to ``"/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh" ``.
+            Defaults to ``"/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc" ``.
         - ``gbasf2_release``: Defaults to the release of your currently set up basf2 release.
           Set this if you want the jobs to use another release on the grid.
         - ``gbasf2_proxy_lifetime``: Defaults to 24. When initializing a proxy, set the
@@ -234,7 +234,7 @@ class Gbasf2Process(BatchProcess):
 
         self.gbasf2_setup_path = get_setting(
             "gbasf2_setup_path",
-            default="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
+            default="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
             task=self.task,
         )
 
@@ -972,7 +972,7 @@ class Gbasf2GridProjectTarget(Target):
         self,
         project_name,
         dirac_user=None,
-        gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
+        gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
     ):
         """
         :param project_name: Name of the gbasf2 grid project that produced the
@@ -1012,7 +1012,7 @@ class Gbasf2GridProjectTarget(Target):
 def check_dataset_exists_on_grid(
     gbasf2_project_name,
     dirac_user=None,
-    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
+    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
 ):
     """Check if an output dataset exists for the gbasf2 project."""
     output_lpn_dir = gbasf2_project_name
@@ -1034,7 +1034,7 @@ def check_dataset_exists_on_grid(
 def get_gbasf2_project_job_status_dict(
     gbasf2_project_name,
     dirac_user=None,
-    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
+    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
 ):
     """
     Returns a dictionary for all jobs in the project with a structure like the
@@ -1091,7 +1091,7 @@ def get_gbasf2_project_job_status_dict(
 def check_project_exists(
     gbasf2_project_name,
     dirac_user=None,
-    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
+    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
 ):
     """Check if we can find the gbasf2 project on the grid with ``gb2_job_status``."""
     try:
@@ -1111,7 +1111,7 @@ def run_with_gbasf2(
     check=True,
     encoding="utf-8",
     capture_output=False,
-    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
+    gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
     **kwargs
 ):
     """
@@ -1178,7 +1178,7 @@ def get_gbasf2_env(gbasf2_setup_path):
     return gbasf2_env
 
 
-def get_proxy_info(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh"):
+def get_proxy_info(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc"):
     """Run ``gbasf2_proxy_info.py`` to retrieve a dict of the proxy status."""
     proxy_info_script_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "gbasf2_utils/gbasf2_proxy_info.py"
@@ -1196,7 +1196,7 @@ def get_proxy_info(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.
 
 
 @lru_cache(maxsize=None)
-def get_dirac_user(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh"):
+def get_dirac_user(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc"):
     """Get dirac user name."""
     # ensure proxy is initialized, because get_proxy_info can't do it, otherwise
     # it causes an infinite loop
@@ -1210,7 +1210,7 @@ def get_dirac_user(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.
         ) from err
 
 
-def setup_dirac_proxy(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh"):
+def setup_dirac_proxy(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc"):
     """Run ``gb2_proxy_init -g belle`` if there's no active dirac proxy. If there is, do nothing."""
     # first run script to check if proxy is already alive or needs to be initalized
     try:
@@ -1278,7 +1278,7 @@ def setup_dirac_proxy(gbasf2_setup_path="/cvmfs/belle.kek.jp/grid/gbasf2/pro/set
 def query_lpns(
     ds_query: str,
     dirac_user: Optional[str] = None,
-    gbasf2_setup_path: str = "/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
+    gbasf2_setup_path: str = "/cvmfs/belle.kek.jp/grid/gbasf2/pro/bashrc",
 ) -> List[str]:
     """
     Query DIRAC for LPNs matching query, and return them as a list.

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -231,42 +231,23 @@ class Gbasf2Process(BatchProcess):
         # Setting it via a setting.json file is not supported to make sure users set unique project names
         self.gbasf2_project_name = get_unique_project_name(self.task)
 
-        gbasf2_setup_path = get_setting(
+
+        self.gbasf2_setup_path = get_setting(
             "gbasf2_setup_path",
-            default=False,
+            default="/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh",
             task=self.task,
         )
-        gbasf2_install_directory = get_setting(
+
+        if get_setting(
             "gbasf2_install_directory",
             default=False,
             task=self.task,
-        )
-        # FIXME: backwards compatibility code to check for the ``gbasf2_install_directory``
-        # setting. Remove this in the future.
-        if gbasf2_install_directory:
-            if gbasf2_setup_path:
-                warnings.warn(
-                    "Both the ``gbasf2_setup_path`` and ``gbasf2_install_directory`` "
-                    "settings are given. Will use ``gbasf2_setup_path``, "
-                    "because ``gbasf2_install_directory`` will be deprecated in "
-                    "future releases.",
-                    PendingDeprecationWarning
-                )
-            else:
-                gbasf2_setup_path = os.path.join(
-                    gbasf2_install_directory, "BelleDIRAC/gbasf2/pro/setup.sh"
-                )
-                warnings.warn(
-                    "The setting ``gbasf2_install_directory`` will be deprecated. "
-                    "Please use the ``gbasf2_setup_path`` setting instead."
-                    "because ``gbasf2_install_directory`` will be deprecated in "
-                    "future releases.",
-                    PendingDeprecationWarning
-                )
-        if gbasf2_setup_path:
-            self.gbasf2_setup_path = gbasf2_setup_path
-        else:
-            self.gbasf2_setup_path = "/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh"
+        ):
+            warnings.warn(
+                "IGNORING deprecated setting `gbasf2_install_directory`" +
+                "Instead set the path to the setup file directly with the `gbasf2_setup_path` setting.",
+                DeprecationWarning
+            )
 
         #: Output file directory of the task to wrap with gbasf2, where we will
         # store the pickled basf2 path and the created steerinfile to execute

--- a/b2luigi/batch/processes/gbasf2.py
+++ b/b2luigi/batch/processes/gbasf2.py
@@ -138,7 +138,7 @@ class Gbasf2Process(BatchProcess):
 
         Other not required, but noteworthy settings are:
 
-        - ``gbasf2_setup_path``: Path to directory where gbasf2 is installed.
+        - ``gbasf2_setup_path``: Path to gbasf2 environment setup script that needs so be sourced to run gbasf2 commands.
             Defaults to ``"/cvmfs/belle.kek.jp/grid/gbasf2/pro/setup.sh" ``.
         - ``gbasf2_release``: Defaults to the release of your currently set up basf2 release.
           Set this if you want the jobs to use another release on the grid.


### PR DESCRIPTION
Changed the default value of the `gbasf2_install_directory` setting and functions which take this as a parameter to the new CVMFS setup script path in gbasf2 v5.8.2. Also fixed the documentation for the setting.

The old setting `gbasf2_install_directory` has been fully deprecated now. Before I tried to use the old setting as a fallback if `gbasf2_setup_path` was not customized but `gbasf2_setup_path` was. But that resulted in some complicated error-prone logic which is annoying to update when gbasf2 changes their setup path. However I still don't raise an exception when the old setting is used and just raise a warning and fall back to the value of `gbas2_install_directory`. Most users just used the default anyway.

The changes are also documented in the updated changelog.

This solves #206 reported by @miverone  and @0ctagon. Please test if this solves the `FileNotFoundError` at least.

The issue comments contain potential other bugs with the new gbasf2 release, but they seem like they should be a separate more complex issue and I'd like to merge this simple path fix first.

Resolves #206